### PR TITLE
Fix/hide swap

### DIFF
--- a/source/components/Actions/index.jsx
+++ b/source/components/Actions/index.jsx
@@ -3,30 +3,19 @@ import { useRouter } from '@components/Router';
 import { ActionButton } from '@ui';
 import useStyles from './styles';
 
-const ACTIONS = (navigator) => [
-  {
-    type: 'deposit',
-    onClick: (() => navigator.navigate('deposit')),
-  },
-  {
-    type: 'send',
-    onClick: (() => navigator.navigate('send')),
-  },
-  // {
-  //   type: 'swap',
-  //   onClick: (() => navigator.navigate('swap')),
-  // },
-];
+const ACTIONS = ['deposit', 'send', 'swap'];
 
 const Actions = () => {
   const classes = useStyles();
   const { navigator } = useRouter();
 
+  // TODO: Re-enable swap when available.
+  const navigate = (route) => () => route !== 'swap' && navigator.navigate(route);
   return (
     <div className={classes.root}>
       {
-        ACTIONS(navigator).map((action) => (
-          <ActionButton key={action.type} type={action.type} onClick={action.onClick} />
+        ACTIONS.map((action) => (
+          <ActionButton key={action} type={action} onClick={navigate(action)} />
         ))
       }
     </div>

--- a/source/ui/ActionButton/index.jsx
+++ b/source/ui/ActionButton/index.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import DepositIcon from '@material-ui/icons/AddRounded';
 import SendIcon from '@material-ui/icons/Telegram';
 import SwapIcon from '@material-ui/icons/SwapHorizRounded';
+import { Tooltip } from '@material-ui/core';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import useStyles from './styles';
@@ -26,6 +27,8 @@ const ACTION_SETTINGS = {
     icon: <SwapIcon style={{ fontSize: '1.3em' }} />,
     iconClass: 'iconSwap',
     textClass: 'textSwap',
+    disabled: true,
+    tooltip: 'Coming soon!',
   },
 };
 
@@ -35,20 +38,37 @@ const ActionButton = ({ type, onClick }) => {
     icon,
     iconClass,
     textClass,
+    disabled,
+    tooltip,
   } = ACTION_SETTINGS[type];
 
   const classes = useStyles();
+  const [hovered, setHovered] = useState(false);
+  const onMouseOver = () => setHovered(true);
+  const onMouseLeave = () => setHovered(false);
 
   return (
-    <HoverAnimation>
-      <div className={classes.root} onClick={onClick}>
-        <IconButton className={clsx(classes.icon, classes[iconClass])}>
-          {icon}
-        </IconButton>
-        <span className={clsx(classes.text, classes[textClass])}>
-          {name}
-        </span>
-      </div>
+    <HoverAnimation disabled={disabled}>
+      <Tooltip
+        title={tooltip}
+        arrow
+        open={!!tooltip && hovered}
+        placement="top"
+      >
+        <div
+          className={classes.root}
+          onClick={onClick}
+          onMouseEnter={onMouseOver}
+          onMouseLeave={onMouseLeave}
+        >
+          <IconButton className={clsx(classes.icon, classes[iconClass])} disabled={disabled}>
+            {icon}
+          </IconButton>
+          <span className={clsx(classes.text, classes[textClass])}>
+            {name}
+          </span>
+        </div>
+      </Tooltip>
     </HoverAnimation>
   );
 };

--- a/source/ui/ActionButton/styles.js
+++ b/source/ui/ActionButton/styles.js
@@ -26,8 +26,7 @@ export default makeStyles((theme) => ({
   },
   iconSwap: {
     background:
-      'radial-gradient(85.62% 86.59% at 48.78% 48.78%, #00E8FF 0%, #47F748 67.19%)',
-    boxShadow: '0px 0px 10px rgba(61, 240, 154, 0.6)',
+      'radial-gradient(85.62% 86.59% at 48.78% 48.78%, whitesmoke 0%, grey 67.19%)',
   },
   textDeposit: {
     background: 'linear-gradient(102.53deg, #FB5DC3 5.45%, #FDB943 96.36%)',
@@ -36,7 +35,7 @@ export default makeStyles((theme) => ({
     background: 'linear-gradient(103.8deg, #36C3E9 5.92%, #CF6ED3 84.31%)',
   },
   textSwap: {
-    background: 'linear-gradient(102.05deg, #09DF66 5.28%, #05DCC8 83.22%)',
+    background: 'linear-gradient(102.05deg, grey 5.28%, darkgrey 83.22%)',
   },
   text: {
     WebkitBackgroundClip: 'text !important',

--- a/source/ui/HoverAnimation/index.jsx
+++ b/source/ui/HoverAnimation/index.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import useStyles from './styles';
 
-const HoverAnimation = ({ children }) => {
+const HoverAnimation = ({ children, disabled }) => {
   const classes = useStyles();
 
   return (
-    <div className={classes.hoverAnimation}>
+    <div className={disabled ? '' : classes.hoverAnimation}>
       {children}
     </div>
   );
@@ -16,4 +16,9 @@ export default HoverAnimation;
 
 HoverAnimation.propTypes = {
   children: PropTypes.node.isRequired,
+  disabled: PropTypes.bool,
+};
+
+HoverAnimation.defaultProps = {
+  disabled: false,
 };


### PR DESCRIPTION
## Changelog
- Greyed out swap button
- Removed navigation
- Removed hover animation
- Added coming soon tooltip
- Added disabled prop to HoverAnimation component

### Clubhouse Tickets Related:

- https://app.clubhouse.io/terminalsystems/story/23056/hide-swap-for-v0

### Screenshots/Gifs:
![image](https://user-images.githubusercontent.com/84542297/123317460-6b32aa00-d504-11eb-9bea-976e02290124.png)