### PR TITLE
feat(help): alter links in help menu

### DIFF
--- a/source/hooks/useHelpItems.jsx
+++ b/source/hooks/useHelpItems.jsx
@@ -15,7 +15,7 @@ const useHelpItems = () => {
     {
       image: NewspaperIcon,
       name: t('help.blog'),
-      onClick: (() => window.open('https://docs.plugwallet.ooo/#resources', '_blank')),
+      onClick: (() => window.open('https://medium.com/plugwallet', '_blank')),
     },
     {
       image: BirdIcon,


### PR DESCRIPTION
This PR changes the help menu by:

- Removing the `review with plug` option for the moment (we might bring it back when we have review pages)
- Update the blog link to point at our medium page medium

## Preview

![image](https://user-images.githubusercontent.com/24030/124613056-c2247180-de6a-11eb-9304-fbaabe0e2a35.png)
