### PR TITLE
docs(readme): signpost alpha in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,5 +123,5 @@ See the original [README](https://github.com/abhijithvijayan/wext-manifest-loade
 
 ## License
 
-Original template MIT © [Abhijith Vijayan](https://abhijithvijayan.in)
 Plug extension © Fleek LLC
+Original template MIT © [Abhijith Vijayan](https://abhijithvijayan.in)


### PR DESCRIPTION
Add a warning to the introduction indicating that plug is alpha and a hot wallet.

Also included:
* build badges from the controller repo
* reformat of the license line at the end of the readme to separate out fleek from the template

## Preview

![image](https://user-images.githubusercontent.com/24030/124751499-9b277780-df1e-11eb-9846-0b13a65df5c4.png)

