### PR TITLE
fix: 🐛 password should not be empty chars (trim input)

### DIFF
--- a/source/Options/Views/Welcome/steps/CreatePasswordStep.jsx
+++ b/source/Options/Views/Welcome/steps/CreatePasswordStep.jsx
@@ -27,7 +27,7 @@ const CreatePasswordStep = ({ handleNextStep, handleSetMnemonic, mnemonic }) => 
   };
 
   const validatePasswordError = () => {
-    if (password === '' || password.length < 12) {
+    if (password.trim() === '' || password.length < 12) {
       return 'welcome.passwordShortError';
     }
 


### PR DESCRIPTION
## Changelog

- Trim user-input on validatePasswordError

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [x] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- [ch23191](https://app.clubhouse.io/terminalsystems/story/23191/password-should-not-validate-empty-character-input)

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
