### PR TITLE
chore: bump version and set firefox extension id

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plug",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Your plug into the Internet Computer",
   "private": true,
   "repository": "https://github.com/Psychedelic/plug",

--- a/source/manifest.json
+++ b/source/manifest.json
@@ -10,8 +10,8 @@
     "128": "assets/icons/favicon-128.png"
   },
   "description": "Your plug into the Internet Computer",
-  "homepage_url": "https://github.com/abhijithvijayan/web-extension-starter",
-  "short_name": "Sample Name",
+  "homepage_url": "https://github.com/psychedelic/plug",
+  "short_name": "Plug",
 
   "permissions": [
     "activeTab",
@@ -29,7 +29,7 @@
 
   "__firefox__applications": {
     "gecko": {
-      "id": "{754FB1AD-CC3B-4856-B6A0-7786F8CA9D17}"
+      "id": "plug@plugwallet.ooo"
     }
   },
 


### PR DESCRIPTION
Set the version of the extension to `0.1.0` to indicate alpha. Set the firefox id to a domain we control.

## Preview

### Firefox

![image](https://user-images.githubusercontent.com/24030/124801879-42240780-df4f-11eb-8b1d-1eb41fae6614.png)

### Chrome

![image](https://user-images.githubusercontent.com/24030/124801996-667fe400-df4f-11eb-885b-c6ea3a04aa74.png)
