### PR TITLE
docs(readme): add note to firefox install about temp nature of plug install

### DIFF
--- a/docs/install-plug-in-firefox.md
+++ b/docs/install-plug-in-firefox.md
@@ -2,6 +2,8 @@
 
 The Plug Firefox addon is currently installed from a developer build.
 
+> **NOTE:** Firefox only allows the installation of temporary developer extensions (they will not persist between firefox restarts). You may wish to install plug with Chrome until it becomes available in Firefox addons as a signed extension. An alternative is to use the Firefox Developer or Nightly editions and turn off the [extension signing requirement](http://mzl.la/1J7Lcsp).
+
 ## Download the latest version of plug 
 
 Download the latest plug firefox xpi file  from the our Github [releases page](https://github.com/Psychedelic/plug/releases):


### PR DESCRIPTION
FF will remove the installed plug extension on restart. A note has been added to the firefox install
guide alerting the reader to this and suggesting the mitigation of using FF nightly with extension
signing turned off.

## Preview

![image](https://user-images.githubusercontent.com/24030/124929210-393b4080-dff8-11eb-9fe8-acf5d9b84191.png)
