### PR TITLE
docs: add security.md 

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+## Plug’s Security Policy & Reporting
+
+Our security and issue reporting policy intends to set a standard that helps protect users, developers, and the project from publicly disclosed security vulnerabilities that haven’t been addressed or fixed. 
+
+To achieve that, we follow a private-first issue reporting policy, where any security issues or vulnerabilities are first to be reported and addressed privately by the core Plug development team. Only after a reasonable review and patching time period goes by that allows users to upgrade, the vulnerability will be publicly disclosed.
+
+We take security and vulnerabilities very seriously, and we are aware that issues may arise despite our best efforts. Any reported issues will be handled timely after being contacted by the channels detailed below. After an issue has been reported we are committed to provide a detailed report on how the issue will be addressed, the time-frame involved, and any rewards involved.
+
+We strongly ask that this process is followed to ensure the safety of users and the project, avoiding malicious exploits, or actions that affect them.
+
+## Reporting a Security Issue
+
+If you find or experience a security vulnerability, please communicate with us and give a detailed report. You can reach us through the following email:
+
+Email us to security@plugwallet.ooo
+You can [click here to do that too](mailto:security@plugwallet.ooo).
+
+Please be aware that this email is exclusively reserved for reporting security issues. We can’t thank enough all contributions made to this, and we’ll always be happy to collaborate!


### PR DESCRIPTION
## Changelog

Add a security advisory and reporting process doc. This is displayed in the security tab by github.