### PR TITLE
style: 💄 use opacity transition instead

### DIFF
--- a/source/Popup/Views/Deposit/styles.js
+++ b/source/Popup/Views/Deposit/styles.js
@@ -24,10 +24,10 @@ export default makeStyles((theme) => ({
     fontSize: 18,
     marginRight: theme.spacing(1),
     cursor: 'pointer',
-    transition: 'transform 0.3s',
+    transition: 'opacity 0.3s',
 
     '&:hover': {
-      transform: 'scale(1.03)',
+      opacity: 0.75,
     },
   },
   iconQrCode: {

--- a/source/components/CopyButton/styles.js
+++ b/source/components/CopyButton/styles.js
@@ -4,10 +4,10 @@ export default makeStyles({
   icon: {
     cursor: 'pointer',
     fontSize: 18,
-    transition: 'transform 0.3s',
+    transition: 'opacity 0.3s',
 
     '&:hover': {
-      transform: 'scale(1.03)',
+      opacity: 0.75,
     },
   },
   copyIcon: {


### PR DESCRIPTION
## Changelog

- Use opacity transition instead to prevent Firefox flicker on icon hover
 
### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [x] Bug fixes
- [x] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- [ch23231](https://app.clubhouse.io/terminalsystems/story/23231/deposit-page-minor-twitch-while-hovering-over-copy-buttons-and-copying)

### Screenshots/Gifs:

Previously:

https://user-images.githubusercontent.com/236752/125444648-73fe1c11-ca34-45c2-8e93-225e3f9301df.mp4

Current:

https://user-images.githubusercontent.com/236752/125444088-71c88541-fae6-4df6-ae7c-904d625d6119.mp4

### Tested on:

- [x] Chrome
- [x] Firefox
- [ ] Safari
