### PR TITLE
Christianlaino/ch23335/fix rejecting a connection from a previously2

### DIFF
--- a/source/Background/Controller.js
+++ b/source/Background/Controller.js
@@ -354,68 +354,7 @@ backgroundController.exposeController('getPublicKey', async (opts) => {
 });
 
 backgroundController.exposeController(
-  'allowAgent',
-  async (opts, metadata, whitelist) => {
-    const { message, sender, callback } = opts;
-
-    const { id: callId } = message.data.data;
-    const { id: portId } = sender;
-
-    storage.get('apps', async (state) => {
-      if (state?.apps?.[metadata.url]?.status === CONNECTION_STATUS.accepted) {
-        const url = qs.stringifyUrl({
-          url: 'notification.html',
-          query: {
-            callId,
-            portId,
-            metadataJson: JSON.stringify(metadata),
-            argsJson: JSON.stringify(whitelist),
-            type: 'allowAgent',
-          },
-        });
-
-        const height = keyring?.isUnlocked
-          ? Math.min(422 + 37 * whitelist.length, 600)
-          : SIZES.loginHeight;
-
-        extension.windows.create({
-          url,
-          type: 'popup',
-          width: SIZES.width,
-          height,
-          top: 65,
-          left: metadata.pageWidth - SIZES.width,
-        });
-      } else {
-        callback(ERRORS.CONNECTION_ERROR, null);
-      }
-    });
-  },
-);
-
-backgroundController.exposeController(
   'handleAllowAgent',
-  async (opts, response, callId, portId) => {
-    const { callback } = opts;
-
-    // Answer this callback no matter if the transfer succeeds or not.
-    callback(null, true);
-
-    if (response) {
-      try {
-        const publicKey = await keyring.getPublicKey();
-        callback(null, publicKey, [{ portId, callId }]);
-      } catch (e) {
-        callback(ERRORS.SERVER_ERROR(e), null, [{ portId, callId }]);
-      }
-    } else {
-      callback(ERRORS.AGENT_REJECTED, null, [{ portId, callId }]);
-    }
-  },
-);
-
-backgroundController.exposeController(
-  'handleAllowAgentConnect',
   async (opts, url, response, callId, portId) => {
     const { callback } = opts;
 

--- a/source/Inpage/index.js
+++ b/source/Inpage/index.js
@@ -18,3 +18,5 @@ window.ic = {
   ...ic,
   plug: plugProvider,
 };
+
+export default plugProvider;

--- a/source/Pages/Notification/components/AllowAgent/index.jsx
+++ b/source/Pages/Notification/components/AllowAgent/index.jsx
@@ -40,13 +40,10 @@ const AllowAgent = ({
   const {
     url,
     icons,
-    requestConnect,
   } = metadata;
 
   const onClickHandler = async (response) => {
-    if (requestConnect) await portRPC.call('handleAllowAgentConnect', [url, response, callId, portId]);
-    else await portRPC.call('handleAllowAgent', [response, callId, portId]);
-
+    await portRPC.call('handleAllowAgent', [response, callId, portId]);
     window.close();
   };
 

--- a/source/Pages/Notification/components/AllowAgent/index.jsx
+++ b/source/Pages/Notification/components/AllowAgent/index.jsx
@@ -40,10 +40,13 @@ const AllowAgent = ({
   const {
     url,
     icons,
+    requestConnect,
   } = metadata;
 
   const onClickHandler = async (response) => {
-    await portRPC.call('handleAllowAgent', [response, callId, portId]);
+    if (requestConnect) await portRPC.call('handleAllowAgentConnect', [url, response, callId, portId]);
+    else await portRPC.call('handleAllowAgent', [response, callId, portId]);
+
     window.close();
   };
 

--- a/source/hooks/useApps.jsx
+++ b/source/hooks/useApps.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 import extension from 'extensionizer';
+import { CONNECTION_STATUS } from '@shared/constants/connectionStatus';
+import plugProvider from '../Inpage/index';
 
 const storage = extension.storage.local;
 
@@ -17,6 +19,7 @@ const useApps = () => {
       }, {});
 
     setApps(filteredApps);
+    plugProvider.deleteAgent();
   };
 
   useEffect(() => {
@@ -33,7 +36,9 @@ const useApps = () => {
       apps,
     });
 
-    setParsedApps(Object.values(apps));
+    const parsed = Object.values(apps);
+    const filtered = parsed.filter((a) => a.status === CONNECTION_STATUS.accepted);
+    setParsedApps(filtered);
   }, [apps]);
 
   return {


### PR DESCRIPTION
## Changelog

- Ccreate plug agent on request connect
- display only status accepted apps
- remove agent on remove app


### Type of changes included:

- [ ] Components
- [x] Business Logic
- [ ] Bug fixes
- [ ] Styling
- [x] Code Refactor

### Clubhouse Tickets Related:

- [CH23335](https://app.clubhouse.io/terminalsystems/story/23335/fix-rejecting-a-connection-from-a-previously-connected-site-should-remove-it-from-the-app-bar-and-remove-the-agent)
- [CH23403](https://app.clubhouse.io/terminalsystems/story/23403/enhance-unify-connect-and-request-agent)


### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
