### PR TITLE
Fix: fixed connection modal not closing on decline

### DIFF
--- a/source/Background/Controller.js
+++ b/source/Background/Controller.js
@@ -341,14 +341,15 @@ backgroundController.exposeController(
 
       storage.set({ apps: newApps });
     });
+    console.log(response.status);
     if (response?.status === CONNECTION_STATUS.accepted) {
       try {
         const publicKey = await keyring.getPublicKey();
         callback(null, publicKey, [{ portId, callId }]);
         callback(null, true);
       } catch (e) {
-        callback(ERRORS.SERVER_ERROR(e), null);
         callback(ERRORS.SERVER_ERROR(e), null, [{ portId, callId }]);
+        callback(null, false);
       }
     } else {
       plugProvider.deleteAgent();

--- a/source/Background/Controller.js
+++ b/source/Background/Controller.js
@@ -341,7 +341,6 @@ backgroundController.exposeController(
 
       storage.set({ apps: newApps });
     });
-    console.log(response.status);
     if (response?.status === CONNECTION_STATUS.accepted) {
       try {
         const publicKey = await keyring.getPublicKey();

--- a/source/Background/Controller.js
+++ b/source/Background/Controller.js
@@ -352,8 +352,8 @@ backgroundController.exposeController(
       }
     } else {
       plugProvider.deleteAgent();
-      callback(ERRORS.AGENT_REJECTED, null);
       callback(ERRORS.AGENT_REJECTED, null, [{ portId, callId }]);
+      callback(null, false);
     }
   },
 );


### PR DESCRIPTION
## Changelog

- Changed response from handleAllowAgent to respond instead of throw, to allow the modal to close

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [X] Bug fixes
- [ ] Styling
- [ ] Code Refactor



### Tested on:

- [X] Chrome
- [ ] Firefox
- [ ] Safari
