### PR TITLE
show whitelisted canister ids on apps

### DIFF
--- a/source/Pages/Notification/components/AllowAgent/index.jsx
+++ b/source/Pages/Notification/components/AllowAgent/index.jsx
@@ -7,6 +7,7 @@ import i18n from 'i18next';
 import { Provider, useDispatch } from 'react-redux';
 import {
   Button, Container, IncomingAction, theme,
+  WhitelistContainer, WhitelistItem,
 } from '@ui';
 import store from '@redux/store';
 import { Layout } from '@components';
@@ -17,8 +18,7 @@ import { CONNECTION_STATUS } from '@shared/constants/connectionStatus';
 import { setAccountInfo } from '@redux/wallet';
 import { HANDLER_TYPES, sendMessage } from '@background/Keyring';
 import initConfig from '../../../../locales';
-import WhitelistContainer from './components/WhitelistContainer';
-import WhitelistItem from './components/WhitelistItem';
+
 import useStyles from './styles';
 
 i18n.use(initReactI18next).init(initConfig);

--- a/source/components/Apps/index.jsx
+++ b/source/components/Apps/index.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Typography from '@material-ui/core/Typography';
-import { AppItem } from '@ui';
-import DeleteImg from '@assets/icons/delete.svg';
+import {
+  AppItem, Dialog, WhitelistContainer, WhitelistItem,
+} from '@ui';
 import ThinkingEmoji from '@assets/icons/thinking-emoji.svg';
 import { useApps } from '@hooks';
 import ActionDialog from '../ActionDialog';
@@ -13,17 +14,25 @@ const Apps = () => {
   const classes = useStyles();
   const { t } = useTranslation();
   const { parsedApps: apps, removeApp } = useApps();
-  const [open, setOpen] = useState(false);
+  const [openDelete, setOpenDelete] = useState(false);
   const [selectedApp, setSelectedApp] = useState(null);
+
+  const [openDetail, setOpenDetail] = useState(false);
+  const [whitelist, setWhitelist] = useState([]);
 
   const handleRemoveApp = (app) => {
     removeApp(app.url);
-    setOpen(false);
+    setOpenDelete(false);
   };
 
-  const handleOpenDialog = (app) => {
+  const handleOpenDelete = (app) => () => {
     setSelectedApp(app);
-    setOpen(true);
+    setOpenDelete(true);
+  };
+
+  const handleOpenDetail = (app) => () => {
+    setWhitelist(app.whitelist);
+    setOpenDetail(true);
   };
 
   if (!apps.length) {
@@ -50,9 +59,8 @@ const Apps = () => {
                 {apps.map((app, index) => (
                   <AppItem
                     key={index.toString()}
-                    onClick={() => handleOpenDialog(app)}
-                    deleteIcon={DeleteImg}
-                    action={t('common.delete')}
+                    onDelete={handleOpenDelete(app)}
+                    onDetail={handleOpenDetail(app)}
                     {...app}
                   />
                 ))}
@@ -62,16 +70,33 @@ const Apps = () => {
         }
       </div>
       {
-        open
+        openDelete
         && (
           <ActionDialog
-            open={open}
+            open={openDelete}
             title={t('apps.disconnectTitle')}
             content={<Typography>{t('apps.disconnectText')} <b>{selectedApp.name}</b>?</Typography>}
             button={t('common.disconnect')}
             buttonVariant="danger"
             onClick={() => handleRemoveApp(selectedApp)}
-            onClose={() => setOpen(false)}
+            onClose={() => setOpenDelete(false)}
+          />
+        )
+      }
+      {
+        openDetail
+        && (
+          <Dialog
+            title={t('apps.whitelistTitle')}
+            onClose={() => setOpenDetail(false)}
+            open={openDetail}
+            component={(
+              <WhitelistContainer style={{ padding: '0 24px' }}>
+                {
+                  whitelist.map((id) => <WhitelistItem canisterId={id} />)
+                }
+              </WhitelistContainer>
+            )}
           />
         )
       }

--- a/source/components/Apps/styles.js
+++ b/source/components/Apps/styles.js
@@ -9,6 +9,8 @@ export default makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'column',
     padding: `0 ${theme.spacing(2)}px ${theme.spacing(0.5)}px`,
+    justifyContent: 'space-between',
+    height: 44,
   },
   centerTextContainer: {
     display: 'flex',

--- a/source/locales/en/translation.json
+++ b/source/locales/en/translation.json
@@ -75,7 +75,8 @@
     "emptyText": "When you connect to an app they will be displayed here, with the ability to remove them.",
     "emptyLink": "our docs.",
     "comingSoonTitle": "Coming soon!",
-    "comingSoonSubtitle": "Plug will allow you to connect\nand log into IC Apps."
+    "comingSoonSubtitle": "Plug will allow you to connect\nand log into IC Apps.",
+    "whitelistTitle": "Approved canister IDs"
   },
   "login": {
     "title": "Welcome Back!",

--- a/source/ui/AppItem/index.jsx
+++ b/source/ui/AppItem/index.jsx
@@ -1,21 +1,34 @@
-import React from 'react';
+import React, { useState } from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
-import useStyles from './styles';
+import DeleteImg from '@assets/icons/delete.svg';
+import { useTranslation } from 'react-i18next';
+import ListIcon from '@material-ui/icons/List';
+import clsx from 'clsx';
 import GenericIcon from '../GenericIcon';
+import useStyles from './styles';
 
 const AppItem = ({
-  name, deleteIcon, icon, action, onClick,
+  name, icon, onDelete, onDetail,
 }) => {
   const classes = useStyles();
+  const { t } = useTranslation();
+  const [hover, setHover] = useState(false);
 
   return (
-    <div className={classes.root}>
+    <div
+      className={classes.root}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
       <GenericIcon image={icon} />
       <Typography variant="h5" className={classes.title}>{name}</Typography>
-      <IconButton className={classes.icon} size="medium" onClick={onClick}>
-        <img src={deleteIcon} alt={action} />
+      <IconButton className={clsx(classes.icon, classes.firstIcon, hover && classes.visible)} size="medium" onClick={onDetail}>
+        <ListIcon />
+      </IconButton>
+      <IconButton size="medium" onClick={onDelete} className={clsx(classes.icon, hover && classes.visible)}>
+        <img src={DeleteImg} alt={t('common.delete')} />
       </IconButton>
     </div>
   );
@@ -25,8 +38,7 @@ export default AppItem;
 
 AppItem.propTypes = {
   name: PropTypes.string.isRequired,
-  deleteIcon: PropTypes.string.isRequired,
   icon: PropTypes.string.isRequired,
-  action: PropTypes.string.isRequired,
-  onClick: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onDetail: PropTypes.func.isRequired,
 };

--- a/source/ui/AppItem/styles.js
+++ b/source/ui/AppItem/styles.js
@@ -9,9 +9,22 @@ export default makeStyles((theme) => ({
     alignItems: 'center',
   },
   icon: {
-    marginLeft: 'auto',
+    width: 40,
+    height: 40,
+    color: '#111827',
+    opacity: 0,
+    transition: 'opacity .6s',
   },
   title: {
     marginLeft: theme.spacing(1),
+    width: 240,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  firstIcon: {
+    marginLeft: 'auto',
+  },
+  visible: {
+    opacity: 1,
   },
 }));

--- a/source/ui/WhitelistContainer/index.jsx
+++ b/source/ui/WhitelistContainer/index.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import useStyles from '../styles';
+import useStyles from './styles';
 
-const WhitelistContainer = ({ children }) => {
+const WhitelistContainer = ({ children, ...other }) => {
   const classes = useStyles();
 
   return (
-    <div className={classes.whitelistContainer}>
+    <div className={classes.whitelistContainer} {...other}>
       {children}
     </div>
   );

--- a/source/ui/WhitelistContainer/styles.js
+++ b/source/ui/WhitelistContainer/styles.js
@@ -1,0 +1,12 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export default makeStyles({
+  whitelistContainer: {
+    display: 'flex',
+    width: '100%',
+    flexDirection: 'column',
+    marginBottom: 24,
+    maxHeight: 173,
+    overflow: 'auto',
+  },
+});

--- a/source/ui/WhitelistItem/index.jsx
+++ b/source/ui/WhitelistItem/index.jsx
@@ -3,7 +3,7 @@ import { Typography } from '@material-ui/core';
 import ArrowUpRight from '@assets/icons/arrow-up-right.png';
 import browser from 'webextension-polyfill';
 import PropTypes from 'prop-types';
-import useStyles from '../styles';
+import useStyles from './styles';
 
 const redirectToICRocks = (canisterId) => () => {
   browser.tabs.create({ url: `https://ic.rocks/principal/${canisterId}` });

--- a/source/ui/WhitelistItem/styles.js
+++ b/source/ui/WhitelistItem/styles.js
@@ -1,0 +1,14 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export default makeStyles({
+  arrowUpRight: {
+    cursor: 'pointer',
+  },
+  whitelistItem: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    width: '100%',
+    padding: '9px 0',
+  },
+});

--- a/source/ui/index.js
+++ b/source/ui/index.js
@@ -33,3 +33,5 @@ export { default as DataDisplay } from './DataDisplay';
 export { default as FullscreenContainer } from './FullscreenContainer';
 export { default as ActionCard } from './ActionCard';
 export { default as Alert } from './Alert';
+export { default as WhitelistContainer } from './WhitelistContainer';
+export { default as WhitelistItem } from './WhitelistItem';


### PR DESCRIPTION
### Clubhouse Tickets Related:

- [enhance-allow-users-to-see-whitelisted-canisters-in-the-extension](https://app.clubhouse.io/terminalsystems/story/23401/enhance-allow-users-to-see-whitelisted-canisters-in-the-extension)

### Screenshots/Gifs:

![yUuL9igBjm](https://user-images.githubusercontent.com/21374862/128066594-d2cbe916-75b8-401e-876a-95ce95b26d2a.gif)

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
