### PR TITLE
Fix: Connect/AllowAgent silent fail

### DIFF
--- a/source/Background/errors.js
+++ b/source/Background/errors.js
@@ -4,7 +4,7 @@ export default {
     message:
       'You are not connected. You must call window.ic.plug.requestConnect() and have the user accept the popup before you call this method.',
   },
-  BALANCE_ERROR: { code: 400, message: 'Insufficient balance.' },
+  BALANCE_ERROR: { code: 400, message: 'Insufficient balance or balance unavailable.' },
   CANISTER_ID_ERROR: { code: 400, message: 'Invalid canister id/s.' },
   TRANSACTION_REJECTED: {
     code: 401,

--- a/source/Pages/Notification/components/AppConnection/index.jsx
+++ b/source/Pages/Notification/components/AppConnection/index.jsx
@@ -16,6 +16,7 @@ import { Layout } from '@components';
 import extension from 'extensionizer';
 import initConfig from '../../../../locales';
 import SIZES from '../Transfer/constants';
+import ErrorScreen from '../NotificationError';
 import useStyles from './styles';
 
 i18n.use(initReactI18next).init(initConfig);
@@ -32,6 +33,7 @@ const AppConnection = () => {
   const classes = useStyles();
   const { t } = useTranslation();
   const [status, setStatus] = useState(null);
+  const [error, setError] = useState(false);
 
   const { query } = qs.parseUrl(window.location.href);
 
@@ -43,8 +45,11 @@ const AppConnection = () => {
   } = query;
 
   const handleResponse = async () => {
-    await portRPC.call('handleAllowAgent', [url, { status, whitelist: [] }, callId, portId]);
-    window.close();
+    const success = await portRPC.call('handleAllowAgent', [url, { status, whitelist: [] }, callId, portId]);
+    if (success) {
+      window.close();
+    }
+    setError(!success);
   };
 
   extension.windows.update(
@@ -71,28 +76,30 @@ const AppConnection = () => {
       <ThemeProvider theme={theme}>
         <CssBaseline />
         <Layout disableProfile>
-          <div className={classes.padTop}>
-            <Container>
-              <IncomingAction url={url} image={icon} action={t('appConnection.connect')} />
-              <div className={classes.buttonContainer}>
-                <Button
-                  variant="default"
-                  value={t('common.decline')}
-                  onClick={() => setStatus(CONNECTION_STATUS.rejected)}
-                  style={{ width: '96%' }}
-                  fullWidth
-                />
-                <Button
-                  variant="rainbow"
-                  value={t('common.allow')}
-                  onClick={() => setStatus(CONNECTION_STATUS.accepted)}
-                  fullWidth
-                  style={{ width: '96%' }}
-                  wrapperStyle={{ textAlign: 'right' }}
-                />
-              </div>
-            </Container>
-          </div>
+          {error ? <ErrorScreen /> : (
+            <div className={classes.padTop}>
+              <Container>
+                <IncomingAction url={url} image={icon} action={t('appConnection.connect')} />
+                <div className={classes.buttonContainer}>
+                  <Button
+                    variant="default"
+                    value={t('common.decline')}
+                    onClick={() => setStatus(CONNECTION_STATUS.rejected)}
+                    style={{ width: '96%' }}
+                    fullWidth
+                  />
+                  <Button
+                    variant="rainbow"
+                    value={t('common.allow')}
+                    onClick={() => setStatus(CONNECTION_STATUS.accepted)}
+                    fullWidth
+                    style={{ width: '96%' }}
+                    wrapperStyle={{ textAlign: 'right' }}
+                  />
+                </div>
+              </Container>
+            </div>
+          )}
         </Layout>
       </ThemeProvider>
     </Provider>

--- a/source/Pages/Notification/components/NotificationError/index.jsx
+++ b/source/Pages/Notification/components/NotificationError/index.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Typography } from '@material-ui/core';
+import { Button } from '@ui';
+import SighEmoji from '@assets/icons/sigh-face.svg';
+
+import useStyles from './styles';
+
+function ErrorScreen() {
+  const { t } = useTranslation();
+  const styles = useStyles();
+  const closeModal = () => window.close();
+  return (
+    <div className={styles.container}>
+      <img src={SighEmoji} className={styles.image} />
+      <Typography variant="h4" className={styles.text}>{t('error.errorTitle')}</Typography>
+      <Typography variant="subtitle2" className={styles.text}>{t('error.notificationError')}</Typography>
+      <Button
+        variant="rainbow"
+        value={t('common.close')}
+        onClick={closeModal}
+      />
+    </div>
+  );
+}
+
+export default ErrorScreen;

--- a/source/Pages/Notification/components/NotificationError/styles.js
+++ b/source/Pages/Notification/components/NotificationError/styles.js
@@ -1,0 +1,25 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export default makeStyles((theme) => ({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: `${theme.spacing(1)}px ${theme.spacing(5.2)}px`,
+    height: '100%',
+    textAlign: 'center',
+    whiteSpace: 'pre-line',
+  },
+  image: {
+    width: 46,
+    height: 46,
+    marginBottom: 20,
+  },
+  text: {
+    marginBottom: 20,
+  },
+  button: {
+    width: 165,
+  },
+}));

--- a/source/Pages/Notification/components/Transfer/hooks/useRequests.jsx
+++ b/source/Pages/Notification/components/Transfer/hooks/useRequests.jsx
@@ -24,6 +24,7 @@ const useRequests = (incomingRequests, callId, portId) => {
   const [requests, setRequests] = useState(incomingRequests);
 
   const [response, setResponse] = useState([]);
+  const [error, setError] = useState(false);
 
   const [accountId, setAccountId] = useState(null);
   const [principalId, setPrincipalId] = useState(null);
@@ -49,8 +50,11 @@ const useRequests = (incomingRequests, callId, portId) => {
 
   useEffect(async () => {
     if (requests.length === 0) {
-      await portRPC.call('handleRequestTransfer', [response, callId, portId]);
-      window.close();
+      const success = await portRPC.call('handleRequestTransfer', [response, callId, portId]);
+      if (success) {
+        window.close();
+      }
+      setError(!success);
     }
   }, [requests]);
 
@@ -102,6 +106,7 @@ const useRequests = (incomingRequests, callId, portId) => {
     handleRequest,
     handleDeclineAll,
     principalId,
+    error,
   };
 };
 

--- a/source/Pages/Notification/components/Transfer/index.jsx
+++ b/source/Pages/Notification/components/Transfer/index.jsx
@@ -11,6 +11,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import getICPPrice from '@shared/services/ICPPrice';
 import { setICPPrice } from '@redux/icp';
 import initConfig from '../../../../locales';
+import ErrorScreen from '../NotificationError';
 import useStyles from './styles';
 import RequestHandler from './components/RequestHandler';
 import useRequests from './hooks/useRequests';
@@ -52,6 +53,7 @@ const Transfer = ({
     handleRequest,
     handleDeclineAll,
     principalId,
+    error,
   } = useRequests([args], callId, portId);
 
   const requestCount = requests.length;
@@ -80,7 +82,9 @@ const Transfer = ({
   return (
     <Layout disableProfile>
 
-      {
+      {error ? <ErrorScreen /> : (
+        <>
+          {
         requestCount > 1
         && (
           <RequestHandler
@@ -91,7 +95,7 @@ const Transfer = ({
           />
         )
         }
-      {
+          {
         requestCount > 0
         && (
           <>
@@ -128,6 +132,8 @@ const Transfer = ({
           </>
         )
       }
+        </>
+      )}
     </Layout>
   );
 };

--- a/source/Popup/Views/Error/index.jsx
+++ b/source/Popup/Views/Error/index.jsx
@@ -11,7 +11,7 @@ import useStyles from './styles';
 function ErrorScreen() {
   const { t } = useTranslation();
   const { navigator } = useRouter();
-  const navigateHome = () => navigator.navigate('home');
+  const navigateHome = () => navigator?.navigate?.('home');
   const styles = useStyles();
   return (
     <Layout>

--- a/source/locales/en/translation.json
+++ b/source/locales/en/translation.json
@@ -284,7 +284,8 @@
   "error": {
     "errorTitle": "Something went wrong",
     "errorBody": "We’re sorry, something weird happened. \nReturn home and retry the action.",
-    "returnHome": "Return Home"
+    "returnHome": "Return Home",
+    "notificationError": "We’re sorry, something weird happened. Please close the pop up and try again"
   },
   "whitelist": {
     "title": "wants to allow calls to the folowing canisters:"


### PR DESCRIPTION
## Changelog

- Ensure locks are updated by calling `init`.
- Added `NotificationError` screen
- Rewired flow to return false when an unexpected error occurs, generally because the user locks the extension while having a popup open

### Type of changes included:

- [X] Components
- [ ] Business Logic
- [X] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Screenshots/Gifs:
![image](https://user-images.githubusercontent.com/84542297/130333832-7cacc7b8-6ba0-4b99-bb80-2437fd51c9d8.png)


### Tested on:

- [X] Chrome
- [ ] Firefox
- [ ] Safari
