### PR TITLE
Removed fee from avail on send reopen

### DIFF
--- a/source/Popup/Views/Send/hooks/useSteps.jsx
+++ b/source/Popup/Views/Send/hooks/useSteps.jsx
@@ -144,7 +144,7 @@ const useSteps = () => {
     if (amount > maxAmount) {
       setAmount(maxAmount);
     }
-  }, [primaryValue]);
+  }, [primaryValue, convertedAmount]);
 
   useEffect(() => {
     setPrimaryValue(
@@ -177,7 +177,7 @@ const useSteps = () => {
         dispatch(setAssets(keyringAssets));
         setAvailableAmount(
           {
-            amount: keyringAssets?.[0]?.amount,
+            amount: keyringAssets?.[0]?.amount - (selectedAsset?.symbol === 'ICP' ? DEFAULT_FEE : 0),
             prefix: primaryValue.prefix,
             suffix: primaryValue.suffix,
           },


### PR DESCRIPTION
## Changelog

- Remove fee from avail balance on app reopen when on send screen

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [X] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Tested on:

- [X] Chrome
- [ ] Firefox
- [ ] Safari
