### PR TITLE
Feature/iframe nft display

### DIFF
--- a/source/Popup/Views/NFTDetails/index.jsx
+++ b/source/Popup/Views/NFTDetails/index.jsx
@@ -36,7 +36,7 @@ const NFTDetails = () => {
     navigator.navigate('home', TABS.NFTS);
   };
 
-  const openNFT = (url) => () => extension.tabs.create({ url: url });
+  const openNFT = (url) => () => extension.tabs.create({ url });
   const openMarketplace = (url) => () => extension.tabs.create({ url: url || entrepotUrl });
   const collection = useMemo(() => collections?.find(
     (col) => col.name === nft?.collection,

--- a/source/Popup/Views/NFTDetails/index.jsx
+++ b/source/Popup/Views/NFTDetails/index.jsx
@@ -36,6 +36,7 @@ const NFTDetails = () => {
     navigator.navigate('home', TABS.NFTS);
   };
 
+  const openNFT = (url) => () => extension.tabs.create({ url: url });
   const openMarketplace = (url) => () => extension.tabs.create({ url: url || entrepotUrl });
   const collection = useMemo(() => collections?.find(
     (col) => col.name === nft?.collection,
@@ -51,7 +52,7 @@ const NFTDetails = () => {
         right={null}
       />
       <div className={classes.container}>
-        <NFTDisplayer url={nft?.url} className={classes.image} />
+        <NFTDisplayer url={nft?.url} onClick={openNFT(nft?.url)} className={classes.image} />
         <div className={classes.buttonContainer}>
           <Button
             variant="default"

--- a/source/Popup/Views/NFTDetails/styles.js
+++ b/source/Popup/Views/NFTDetails/styles.js
@@ -7,6 +7,7 @@ export default makeStyles(() => ({
     height: 280,
     margin: 'auto',
     boxShadow: 'rgb(37 41 46 / 20%) 0px 10px 30px',
+    cursor: 'pointer',
   },
   buttonContainer: {
     width: '100%',

--- a/source/components/NFTs/components/NFTCollection/index.jsx
+++ b/source/components/NFTs/components/NFTCollection/index.jsx
@@ -28,7 +28,7 @@ function NFTCollection({ collection }) {
             className={classes.nftContainer}
             onClick={() => handleNftClick(nft)}
           >
-            <NFTDisplayer url={nft.url} className={classes.nft} />
+            <NFTDisplayer url={nft.url} className={classes.nft} onClick={() => handleNftClick(nft)}/>
             <Typography className={classes.id} variant="subtitle1">{nft.name || `#${nft.index}`}</Typography>
           </div>
         ))

--- a/source/components/NFTs/components/NFTCollection/index.jsx
+++ b/source/components/NFTs/components/NFTCollection/index.jsx
@@ -28,7 +28,11 @@ function NFTCollection({ collection }) {
             className={classes.nftContainer}
             onClick={() => handleNftClick(nft)}
           >
-            <NFTDisplayer url={nft.url} className={classes.nft} onClick={() => handleNftClick(nft)}/>
+            <NFTDisplayer
+              url={nft.url}
+              className={classes.nft}
+              onClick={() => handleNftClick(nft)}
+            />
             <Typography className={classes.id} variant="subtitle1">{nft.name || `#${nft.index}`}</Typography>
           </div>
         ))

--- a/source/ui/NFTDisplayer/index.jsx
+++ b/source/ui/NFTDisplayer/index.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import useStyles from './styles.js';
+import useStyles from './styles';
 
 const TYPE_MAP = {
   'video/mp4': 'video',
@@ -21,7 +21,7 @@ const TAG_PROPS = {
   },
 };
 
-const NFTDisplayer = ({ url, className, onClick, }) => {
+const NFTDisplayer = ({ url, className, onClick }) => {
   const classes = useStyles();
   const [type, setType] = useState('image/png');
 
@@ -41,7 +41,7 @@ const NFTDisplayer = ({ url, className, onClick, }) => {
         className={`${classes.iframeWrapper} ${className}`}
         onClick={onClick}
       >
-        <span className={classes.iframeClick}/>
+        <span className={classes.iframeClick} />
         <Tag
           className={className}
           {...customProps}
@@ -69,6 +69,7 @@ NFTDisplayer.propTypes = {
 
 NFTDisplayer.defaultProps = {
   className: '',
+  onClick: () => {},
 };
 
 export default NFTDisplayer;

--- a/source/ui/NFTDisplayer/index.jsx
+++ b/source/ui/NFTDisplayer/index.jsx
@@ -1,9 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import useStyles from './styles.js';
 
 const TYPE_MAP = {
   'video/mp4': 'video',
   'image/png': 'img',
+  'text/html': 'iframe',
 };
 
 const TAG_PROPS = {
@@ -12,9 +14,15 @@ const TAG_PROPS = {
     muted: true,
     loop: true,
   },
+  iframe: {
+    width: 112,
+    height: 112,
+    loading: 'lazy',
+  },
 };
 
-const NFTDisplayer = ({ url, className }) => {
+const NFTDisplayer = ({ url, className, onClick, }) => {
+  const classes = useStyles();
   const [type, setType] = useState('image/png');
 
   useEffect(() => {
@@ -27,9 +35,26 @@ const NFTDisplayer = ({ url, className }) => {
   const Tag = TYPE_MAP[type] || 'img';
   const customProps = TAG_PROPS[Tag] || {};
 
+  if (Tag === 'iframe') {
+    return (
+      <div
+        className={`${classes.iframeWrapper} ${className}`}
+        onClick={onClick}
+      >
+        <span className={classes.iframeClick}/>
+        <Tag
+          className={className}
+          {...customProps}
+          src={url}
+        />
+      </div>
+    );
+  }
+
   return (
     <Tag
       {...customProps}
+      onClick={onClick}
       className={className}
       src={url}
     />
@@ -39,6 +64,7 @@ const NFTDisplayer = ({ url, className }) => {
 NFTDisplayer.propTypes = {
   url: PropTypes.string.isRequired,
   className: PropTypes.string,
+  onClick: PropTypes.func,
 };
 
 NFTDisplayer.defaultProps = {

--- a/source/ui/NFTDisplayer/styles.js
+++ b/source/ui/NFTDisplayer/styles.js
@@ -1,0 +1,19 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export default makeStyles({
+  iframeWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    position: 'relative',
+    '& > iframe': {
+      border: 'none',
+    },
+  },
+  iframeClick: {
+    position: 'absolute',
+    height: '100%',
+    width: '100%',
+    zIndex: 10000,
+  },
+});


### PR DESCRIPTION
## Changelog

- Allowing for iframe loading on nfts
- Added click on `NFTDetail` to open nft in a tab

### Type of changes included:

- [x] Components
- [ ] Business Logic
- [ ] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- Ticket 1
- Ticket 2
- Ticket 3

### Screenshots/Gifs:

[example](https://imgur.com/BFLufsE)

### Notes:

*Place special notes here*

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
