### PR TITLE
Removed the modal while sending the assets

### DIFF
--- a/source/Popup/Views/Send/hooks/useSteps.jsx
+++ b/source/Popup/Views/Send/hooks/useSteps.jsx
@@ -30,7 +30,6 @@ const useSteps = () => {
   const [selectedAsset, setSelectedAsset] = useState(assets?.[0] || CURRENCIES.get('ICP'));
 
   const [amount, setAmount] = useState(0);
-  const [transaction, setTransaction] = useState(null);
   const [address, setAddress] = useState(null);
   const [addressInfo, setAddressInfo] = useState({ isValid: null, type: null });
   const [trxComplete, setTrxComplete] = useState(false);
@@ -97,7 +96,6 @@ const useSteps = () => {
           sendMessage({ type: HANDLER_TYPES.GET_TRANSACTIONS, params: {} },
             (transactions) => {
               dispatch(setTransactions({ ...transactions, icpPrice }));
-              setTransaction(transactions?.transactions[0]);
             });
         }
       });
@@ -320,8 +318,7 @@ const useSteps = () => {
         addressInfo={addressInfo}
         handleSendClick={handleSendClick}
         error={sendError}
-        transaction={transaction}
-        trxComplete={trxComplete}
+        isTrxCompleted={trxComplete}
       />,
       left: <LinkButton value={t('common.back')} onClick={() => handlePreviousStep()} startIcon={BackIcon} />,
       right: rightButton,


### PR DESCRIPTION
## Changelog

- Removed `awaiting` modal when sending the assets
- Added `useEffect` to move to the activity when trx is finished

### Type of changes included:

- [ ] Components
- [X] Business Logic
- [ ] Bug fixes
- [X] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- https://app.shortcut.com/terminalsystems/story/24183/fix-list-of-changes-from-royce

### Screenshots/Gifs:

https://user-images.githubusercontent.com/32408893/137961646-bad7031d-5eaa-42d7-b5e5-c896ed168052.mov

### Tested on:

- [X] Chrome
- [ ] Firefox
- [ ] Safari
