### PR TITLE
Persisting connected apps through principalId

### DIFF
--- a/source/hooks/useApps.jsx
+++ b/source/hooks/useApps.jsx
@@ -9,26 +9,25 @@ const storage = extension.storage.local;
 const useApps = () => {
   const [apps, setApps] = useState({});
   const [parsedApps, setParsedApps] = useState([]);
-  const { walletNumber } = useSelector((state) => state.wallet);
+  const { principalId } = useSelector((state) => state.wallet);
 
   const handleRemoveApp = (url) => {
     const newApps = removeAppByURL({ apps, url });
-
     setApps(newApps);
   };
 
   useEffect(() => {
-    storage.get(walletNumber?.toString(), (state) => {
-      const appsFromExtensionStorage = state?.[walletNumber]?.apps;
+    storage.get(principalId?.toString(), (state) => {
+      const appsFromExtensionStorage = state?.[principalId]?.apps;
       if (appsFromExtensionStorage) {
         setApps(appsFromExtensionStorage);
       }
     });
-  }, [walletNumber]);
+  }, [principalId]);
 
   useEffect(() => {
     storage.set({
-      [walletNumber]: { apps },
+      [principalId]: { apps },
     });
     const parsed = Object.values(apps);
     const filtered = parsed.filter((a) => a.status === CONNECTION_STATUS.accepted);


### PR DESCRIPTION
## Changelog

- Persists connected apps through different account import

> 💡  We should probably do the same for the contacts and persist those even if different account is imported

### Type of changes included:

- [ ] Components
- [x] Business Logic
- [ ] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- Ticket 1
- Ticket 2
- Ticket 3

### Screenshots/Gifs:


### Notes:

*Place special notes here*

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
