### PR TITLE
Remove thumbnail type from nft view link

### DIFF
--- a/source/Popup/Views/NFTDetails/index.jsx
+++ b/source/Popup/Views/NFTDetails/index.jsx
@@ -56,7 +56,7 @@ const NFTDetails = () => {
             value={t('nfts.expandNFT')}
             style={{ width: '96%' }}
             fullWidth
-            onClick={openNFT(nft?.url)}
+            onClick={openNFT(nft?.url?.replace('type=thumbnail', ''))}
             startIcon={(
               <Maximize2
                 size="20"


### PR DESCRIPTION
## Changelog

- Remove `type=thumbnail` from `nft?.url` on `nfts.expandNFT` button.

### Type of changes included:

- [x] Components
- [ ] Business Logic
- [ ] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

None

### Screenshots/Gifs:

![image](https://user-images.githubusercontent.com/60938577/142493189-e4072028-2eef-48fc-ad50-a136b3500321.png)
__The button in question.__

### Notes:

I believe this is a UX improvement. The technical implementation could be maybe a little tidier, if someone more familiar with the application wants to correct me.

The button seems to express the intent to see a "full" version of the NFT. When it then displays a thumbnail version, that would be jarring to the end user. This is corroborated by the first users of the Saga Legends NFT series.

Each NFT project has it's own implementation and I wouldn't ask for something that made my project better while making others' worse. AFAIK these preview URLs are not explicitly prescribed by any EXT documentation or other standard docs. For that reason, testing on a wallet that contains one of each NFT from all collections in DAB might be worth while (I do not have such a wallet.) That said, I think it's a simple enough change to push even without that testing.

### Tested on:

- [x] Chrome
- [x] Firefox
- [x] Safari
