### PR TITLE
Fixed error message not being shown on a failed nft transfer

### DIFF
--- a/source/Popup/Views/SendNFT/index.jsx
+++ b/source/Popup/Views/SendNFT/index.jsx
@@ -32,7 +32,7 @@ const SendNFT = () => {
   const [address, setAddress] = useState(null);
   const [loading, setLoading] = useState(false);
   const { navigator } = useRouter();
-  const [error, setError] = useState(false);
+  const [errorMessage, setError] = useState('');
   const dispatch = useDispatch();
   const { selectedNft: nft } = useSelector((state) => state.nfts);
   const { collections, principalId } = useSelector((state) => state.wallet);
@@ -41,7 +41,7 @@ const SendNFT = () => {
     setLoading(true);
     setError(false);
     sendMessage({ type: HANDLER_TYPES.TRANSFER_NFT, params: { nft, to: address } },
-      (success) => {
+      ({ success, error }) => {
         setLoading(false);
         if (success) {
           dispatch(setCollections({
@@ -52,7 +52,7 @@ const SendNFT = () => {
           dispatch(setSelectedNft(null));
           navigator.navigate('home', TABS.NFTS);
         } else {
-          setError(true);
+          setError(error || t('nfts.transferError'));
         }
       });
   };
@@ -121,13 +121,13 @@ const SendNFT = () => {
               loading={loading}
             />
           </Grid>
-          {error && (
+          {errorMessage?.length > 0 && (
             <Grid item xs={12}>
               <div className={classes.appearAnimation}>
                 <Alert
                   type="danger"
                   title={(
-                    <span>{t('nfts.transferError')}</span>
+                    <span>{errorMessage}</span>
                   )}
                 />
               </div>


### PR DESCRIPTION
## Changelog

- Fixed error where a failed nft send would not show any errors and just redirect to the nfts screen.

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [X] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:
https://app.shortcut.com/terminalsystems/story/24480/fix-nft-send

### Screenshots/Gifs:
![image](https://user-images.githubusercontent.com/84542297/144655591-ee93b935-2095-4088-87c8-fb0e293c66ea.png)

### Tested on:

- [X] Chrome
- [ ] Firefox
- [ ] Safari
