### PR TITLE
Apps icon rounded square

### DIFF
--- a/source/ui/ActivityItem/styles.js
+++ b/source/ui/ActivityItem/styles.js
@@ -12,7 +12,7 @@ export default makeStyles((theme) => ({
     width: 41,
     boxShadow:
       '0px 0px 0px rgba(6, 44, 82, 0.1), 0px 1px 3px rgba(64, 66, 69, 0.12), 0px 2px 16px rgba(33, 43, 54, 0.08)',
-    borderRadius: 26,
+    borderRadius: 10,
   },
   leftContainer: {
     display: 'flex',

--- a/source/ui/CanisterInfo/components/Item/styles.js
+++ b/source/ui/CanisterInfo/components/Item/styles.js
@@ -17,7 +17,7 @@ export default makeStyles((theme) => ({
   image: {
     width: theme.spacing(3),
     height: theme.spacing(3),
-    borderRadius: '100%',
+    borderRadius: '10px',
     marginRight: theme.spacing(1),
     objectFit: 'cover',
   },

--- a/source/ui/IncomingAction/styles.js
+++ b/source/ui/IncomingAction/styles.js
@@ -4,7 +4,7 @@ export default makeStyles((theme) => ({
   image: {
     height: 51,
     width: 51,
-    borderRadius: 26,
+    borderRadius: 12,
     background: theme.palette.common.primaryBlack,
     marginBottom: theme.spacing(1),
   },


### PR DESCRIPTION
## Changelog

- made app icons rounded square

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [ ] Bug fixes
- [x] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- [sc24481](https://app.shortcut.com/terminalsystems/story/24481/fix-make-connected-apps-rounded-squares)

### Screenshots/Gifs:

![](https://cdn.discordapp.com/attachments/833375276549013504/918937546464055296/Screen_Shot_2021-12-10_at_15.49.39.png)

### Notes:

*Place special notes here*

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
