### PR TITLE
Removed value from assets when not icp or cycle based

### DIFF
--- a/source/shared/constants/currencies.js
+++ b/source/shared/constants/currencies.js
@@ -70,8 +70,8 @@ export const formatAssetBySymbol = (_amount, symbol, icpPrice) => {
         image: TOKEN_IMAGES.WICP,
         symbol: 'WICP',
       },
-      default: { amount, value: amount },
-    }[symbol || 'default'] || { amount, value: amount }
+      default: { amount },
+    }[symbol || 'default'] || { amount }
   );
 };
 

--- a/source/ui/AssetItem/index.jsx
+++ b/source/ui/AssetItem/index.jsx
@@ -20,9 +20,11 @@ const AssetItem = ({
           <NumberFormat value={amount} displayType="text" decimalScale={5} fixedDecimalScale thousandSeparator="," suffix={` ${symbol}`} />
         </Typography>
       </div>
-      <Typography variant="h5" className={clsx(classes.value, (loading) && classes.pulse)}>
-        <NumberFormat value={value} displayType="text" decimalScale={2} fixedDecimalScale thousandSeparator="," prefix="$" />
-      </Typography>
+      { value && (
+        <Typography variant="h5" className={clsx(classes.value, (loading) && classes.pulse)}>
+          <NumberFormat value={value} displayType="text" decimalScale={2} fixedDecimalScale thousandSeparator="," prefix="$" />
+        </Typography>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Changelog
- Removed asset value when token is not cycle or icp based

### Type of changes included:

- [ ] Components
- [X] Business Logic
- [X] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Screenshots/Gifs:
![image](https://user-images.githubusercontent.com/12738697/147749924-2d6a6f78-15b4-4ff2-80e0-db5891038a16.png)



### Tested on:

- [X] Chrome
- [ ] Firefox
- [ ] Safari
