### PR TITLE
Changed onclose for onbeforeunload

### DIFF
--- a/source/Pages/Notification/index.jsx
+++ b/source/Pages/Notification/index.jsx
@@ -81,7 +81,7 @@ const NotificationContainer = () => {
     };
   }, [onTimeout]);
 
-  window.onclose = () => onTimeout?.();
+  window.onbeforeunload = () => onTimeout?.();
 
   const handleLogin = () => setLoggedIn(true);
   const Component = NOTIFICATION_COMPONENTS[type];


### PR DESCRIPTION
## Changelog
- Replaced onclose with onbeforeunload to make modals throw on close

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [X] Bug fixes
- [ ] Styling
- [ ] Code Refactor


