### PR TITLE
✨ display svg's as iframes

### DIFF
--- a/source/ui/NFTDisplayer/index.jsx
+++ b/source/ui/NFTDisplayer/index.jsx
@@ -6,6 +6,7 @@ const TYPE_MAP = {
   'video/mp4': 'video',
   'image/png': 'img',
   'text/html': 'iframe',
+  'image/svg+xml': 'iframe',
 };
 
 const TAG_PROPS = {


### PR DESCRIPTION
## Changelog

- mapping type `image/svg+xml` to `iframe`

### Type of changes included:

- [x] Components
- [ ] Business Logic
- [ ] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Screenshots/Gifs:

![animated](https://user-images.githubusercontent.com/32162112/149841397-ddaf8c70-ed4c-4799-a418-e171f1464fa7.gif)

### Notes:
The goal is to display animated SVGs correctly within plug. Therefore  the mapping from `image/svg+xml` to `iframe` was provided. **Unfortunately I wasn't able to test this in plug**, as the canister I'm using for test deployment isn't available in DAB and I wasn't able to inject it into plug. As reference I screen captured the above GIF to show that it works in stoic wallet using the following [code](https://github.com/letmejustputthishere/stoic-wallet/blob/807cd055d8d02c1869ad0f0b9f7ac2d1698b075f/src/components/NFTList.js#L391).

If you want to test it on the canister I'm using feel free to leave an address/principal and I'll send a couple of NFTs over. The NFT I'm displaying in the GIF is [this one](https://pd52w-iiaaa-aaaae-qaaya-cai.raw.ic0.app/?tokenid=vwlw2-sakor-uwiaa-aaaaa-beaag-aaqca-aaaaa-q).

Please let me know if there's anything else I can provide! 

Thanks!

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
