### PR TITLE
Revert "✨ display svg's as iframes"

### DIFF
--- a/source/ui/NFTDisplayer/index.jsx
+++ b/source/ui/NFTDisplayer/index.jsx
@@ -7,7 +7,6 @@ const TYPE_MAP = {
   'video/mp4': 'video',
   'image/png': 'img',
   'text/html': 'iframe',
-  'image/svg+xml': 'iframe',
 };
 
 const TAG_PROPS = {


### PR DESCRIPTION
Reverts Psychedelic/plug#343

@letmejustputthishere we need to revert this as it's breaking other svg based collections on firefox browser, causing them to display incorrectly both in the NFT tab and the details page. 
We've tried using `embed` and `object` but seems not to work throwing some CORS errors 🤔

Read in #plug chat that you were able to display it successfully using an `object` tag. Could you elaborate on this a bit more? 