### PR TITLE
duplicated burn xtc timeout

### DIFF
--- a/source/Pages/Notification/components/BurnXTC/hooks/useRequests.jsx
+++ b/source/Pages/Notification/components/BurnXTC/hooks/useRequests.jsx
@@ -10,7 +10,7 @@ import { XTC_FEE } from '@shared/constants/addresses';
 const portRPC = new PortRPC({
   name: 'notification-port',
   target: 'bg-script',
-  timeout: 20000,
+  timeout: 40000,
 });
 
 portRPC.start();


### PR DESCRIPTION
## Changelog
- Duplicate burnXTC timeout on rpc endpoint
