### PR TITLE
fix custome token add bug

### DIFF
--- a/source/Popup/Views/AddToken/components/CustomToken.jsx
+++ b/source/Popup/Views/AddToken/components/CustomToken.jsx
@@ -38,7 +38,7 @@ const CustomToken = ({ handleChangeSelectedToken }) => {
     setLoading(true);
     sendMessage({
       type: HANDLER_TYPES.GET_TOKEN_INFO,
-      params: { canisterId, standard: standard.toLowerCase() },
+      params: { canisterId, standard: standard },
     }, async (tokenInfo) => {
       if (tokenInfo?.error) {
         setTokenError(true);


### PR DESCRIPTION
## Changelog

- Fixed bug where we couldn't add custom tokens

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [X] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

https://www.notion.so/Plug-Extension-631a299f3ec14b9c9522e29a9800e923?p=5e44fb0e6f864c1c929067486135d86e

### Screenshots/Gifs:
<img width="425" alt="Captura de Pantalla 2022-03-02 a la(s) 11 09 05" src="https://user-images.githubusercontent.com/5209421/156341760-4ff8b198-eb15-4582-90ef-2af639fa7ed8.png">



### Notes:

We need to do param sanitization in the controller also to use the DAB JS token standards constants. We could do it only on the controller side but I think that would be a bad practice. 
### Tested on:

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
