### PR TITLE
Fix: Fallback WICP id for canister validation

### DIFF
--- a/source/shared/constants/canisters.js
+++ b/source/shared/constants/canisters.js
@@ -2,4 +2,5 @@ export const PROTECTED_CATEGORIES = ['nft', 'asset'];
 export const DAB_CANISTER_ID = 'aipdg-waaaa-aaaah-aaq5q-cai';
 export const XTC_CANISTER_ID = 'aanaa-xaaaa-aaaah-aaeiq-cai';
 export const ICP_CANISTER_ID = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
-export const ASSET_CANISTER_IDS = [XTC_CANISTER_ID, ICP_CANISTER_ID];
+export const WICP_CANISTER_ID = 'utozz-siaaa-aaaam-qaaxq-cai';
+export const ASSET_CANISTER_IDS = [XTC_CANISTER_ID, ICP_CANISTER_ID, WICP_CANISTER_ID];


### PR DESCRIPTION
## Changelog

- Added WICP id to the list of protected ids in case DAB fails to fetch tokens.

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [X] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:
https://www.notion.so/Plug-Extension-631a299f3ec14b9c9522e29a9800e923?p=64d9aaa7cc9c4bee981b6dc3fa96ae2a
