### PR TITLE
ConnectionModule / BackgroundScript refactor

### DIFF
--- a/source/Background/Controller.js
+++ b/source/Background/Controller.js
@@ -12,7 +12,7 @@ import {
   getApp,
   setApps,
   removeApp,
-  connectionModule,
+  ConnectionModule,
 } from '@modules';
 import {
   /* PROTECTED_CATEGORIES, */ ASSET_CANISTER_IDS,
@@ -39,7 +39,7 @@ const DEFAULT_CURRENCY_MAP = {
   XTC: 1,
 };
 
-let keyring;
+let keyring = {};
 
 const backgroundController = new BackgroundController({
   name: 'bg-script',
@@ -271,8 +271,8 @@ backgroundController.exposeController(
 init();
 
 // Exposing module methods
-const ConnectionModule = new connectionModule(backgroundController, secureController, keyring);
-ConnectionModule.exposeMethods(backgroundController);
+const connectionModule = new ConnectionModule(backgroundController, secureController, keyring);
+connectionModule.exposeMethods();
 
 const requestBalance = async (accountId, callback) => {
   const getBalance = getKeyringHandler(HANDLER_TYPES.GET_BALANCE, keyring);

--- a/source/Background/Controller.js
+++ b/source/Background/Controller.js
@@ -7,7 +7,15 @@ import PlugController from '@psychedelic/plug-controller';
 import { validatePrincipalId } from '@shared/utils/ids';
 import { E8S_PER_ICP, CYCLES_PER_TC } from '@shared/constants/currencies';
 import { XTC_FEE } from '@shared/constants/addresses';
-import { getApps, setApps, removeApp } from '@modules';
+import {
+  getApps,
+  getApp,
+  setApps,
+  removeApp,
+  isConnected,
+  disconnect,
+  requestConnect,
+} from '@modules';
 import {
   /* PROTECTED_CATEGORIES, */ ASSET_CANISTER_IDS,
   ICP_CANISTER_ID,
@@ -143,6 +151,9 @@ const secureController = async (callback, controller) => {
   }
 };
 
+// EXPOSED METHODS
+
+/* DEPRECATED
 backgroundController.exposeController('isConnected', async (opts, url) => secureController(opts.callback, async () => {
   const { callback } = opts;
 
@@ -154,7 +165,9 @@ backgroundController.exposeController('isConnected', async (opts, url) => secure
     }
   });
 }));
+*/
 
+/* DEPRECATED
 backgroundController.exposeController('disconnect', async (opts, url) => secureController(opts.callback, async () => {
   removeApp(keyring.currentWalletId.toString(), url, (removed) => {
     if (!removed) {
@@ -162,7 +175,9 @@ backgroundController.exposeController('disconnect', async (opts, url) => secureC
     }
   });
 }));
+*/
 
+/* DEPRECATED
 backgroundController.exposeController(
   'requestConnect',
   async (opts, metadata, whitelist, timeout) => secureController(opts.callback, async () => {
@@ -253,6 +268,28 @@ backgroundController.exposeController(
         height,
       });
     }
+  }),
+);
+*/
+
+backgroundController.exposeController(
+  isConnected.methodName,
+  async (opts, url) => secureController(opts.callback, async () => {
+    isConnected.handler(opts, url, keyring);
+  }),
+);
+
+backgroundController.exposeController(
+  disconnect.methodName,
+  async (opts, url) => secureController(opts.callback, async () => {
+    disconnect.handler(opts, url, keyring);
+  }),
+);
+
+backgroundController.exposeController(
+  requestConnect.methodName,
+  async (opts, metadata, whitelist, timeout) => secureController(opts.callback, async () => {
+    requestConnect.handler(opts, metadata, whitelist, timeout, keyring);
   }),
 );
 

--- a/source/Background/Controller.js
+++ b/source/Background/Controller.js
@@ -12,9 +12,7 @@ import {
   getApp,
   setApps,
   removeApp,
-  isConnected,
-  disconnect,
-  requestConnect,
+  connectionModule,
 } from '@modules';
 import {
   /* PROTECTED_CATEGORIES, */ ASSET_CANISTER_IDS,
@@ -151,8 +149,6 @@ const secureController = async (callback, controller) => {
   }
 };
 
-// EXPOSED METHODS
-
 /* DEPRECATED
 backgroundController.exposeController('isConnected', async (opts, url) => secureController(opts.callback, async () => {
   const { callback } = opts;
@@ -272,26 +268,11 @@ backgroundController.exposeController(
 );
 */
 
-backgroundController.exposeController(
-  isConnected.methodName,
-  async (opts, url) => secureController(opts.callback, async () => {
-    isConnected.handler(opts, url, keyring);
-  }),
-);
+init();
 
-backgroundController.exposeController(
-  disconnect.methodName,
-  async (opts, url) => secureController(opts.callback, async () => {
-    disconnect.handler(opts, url, keyring);
-  }),
-);
-
-backgroundController.exposeController(
-  requestConnect.methodName,
-  async (opts, metadata, whitelist, timeout) => secureController(opts.callback, async () => {
-    requestConnect.handler(opts, metadata, whitelist, timeout, keyring);
-  }),
-);
+// Exposing module methods
+const ConnectionModule = new connectionModule(backgroundController, secureController, keyring);
+ConnectionModule.exposeMethods(backgroundController);
 
 const requestBalance = async (accountId, callback) => {
   const getBalance = getKeyringHandler(HANDLER_TYPES.GET_BALANCE, keyring);

--- a/source/Background/Controller.js
+++ b/source/Background/Controller.js
@@ -9,9 +9,7 @@ import { E8S_PER_ICP, CYCLES_PER_TC } from '@shared/constants/currencies';
 import { XTC_FEE } from '@shared/constants/addresses';
 import {
   getApps,
-  getApp,
   setApps,
-  removeApp,
   ConnectionModule,
 } from '@modules';
 import {

--- a/source/Modules/Controller/connection.js
+++ b/source/Modules/Controller/connection.js
@@ -12,183 +12,189 @@ import {
 } from '../storageManager';
 import SIZES from '../../Pages/Notification/components/Transfer/constants';
 
-// Utils
-const fetchCanistersInfo = async (whitelist) => {
-  if (whitelist && whitelist.length > 0) {
-    const canistersInfo = await Promise.all(
-      whitelist.map(async (id) => {
-        let canisterInfo = { id };
-
-        try {
-          const fetchedCanisterInfo = await PlugController.getCanisterInfo(id);
-          canisterInfo = { id, ...fetchedCanisterInfo };
-        } catch (error) {
-          /* eslint-disable-next-line */
-          console.error(error);
-        }
-
-        return canisterInfo;
-      }),
-    );
-
-    const sortedCanistersInfo = canistersInfo.sort((a, b) => {
-      if (a.name && !b.name) return -1;
-      return 1;
-    });
-
-    return sortedCanistersInfo;
+export class ConnectionModule {
+  constructor(backgroundController, secureController, keyring) {
+    this.keyring = keyring;
+    this.secureController = secureController;
+    this.backgroundController = backgroundController;
   }
 
-  return [];
-};
-
-// Handler objects
-const isConnected = {
-  methodName: 'isConnected',
-  handler: async (opts, url, keyring) => {
-    const { callback } = opts;
-
-    getApp(keyring.currentWalletId.toString(), url, (app) => {
-      if (app) {
-        callback(null, app.status === CONNECTION_STATUS.accepted);
-        return;
-      }
-
-      callback(null, false);
-    });
-  },
-};
-
-const disconnect = {
-  methodName: 'disconnect',
-  handler: async (opts, url, keyring) => {
-    removeApp(keyring.currentWalletId.toString(), url, (removed) => {
-      if (!removed) {
-        opts.callback(ERRORS.CONNECTION_ERROR, null);
-      }
-    });
-  },
-};
-
-const requestConnect = {
-  methodName: 'requestConnect',
-  handler: async (opts, metadata, whitelist, timeout, keyring) => {
-    console.log('handler opts ->', opts);
-    console.log('handler metadata ->', metadata);
-    console.log('handler keyring ->', keyring);
-    let canistersInfo = [];
-    const isValidWhitelist = Array.isArray(whitelist) && whitelist.length;
-    if (!whitelist.every((canisterId) => validatePrincipalId(canisterId))) {
-      opts.callback(ERRORS.CANISTER_ID_ERROR, null);
-      return;
-    }
-    const { message, sender } = opts;
-    const { id: callId } = message.data.data;
-    const { id: portId } = sender;
-    const { url: domainUrl, name, icons } = metadata;
-
-    if (isValidWhitelist) {
-      canistersInfo = await fetchCanistersInfo(whitelist);
-    }
-
-    const date = new Date().toISOString();
-
-    getApps(keyring.currentWalletId.toString(), (apps = {}) => {
-      const newApps = {
-        ...apps,
-        [domainUrl]: {
-          url: domainUrl,
-          name,
-          status: CONNECTION_STATUS.pending,
-          icon: icons[0] || null,
-          timeout,
-          date,
-          events: [
-            ...apps[domainUrl]?.events || [],
-          ],
-          whitelist,
-        },
-      };
-      setApps(keyring.currentWalletId.toString(), newApps);
-    });
-
-    // if we receive a whitelist, we create agent
-    if (isValidWhitelist) {
-      const newMetadata = { ...metadata, requestConnect: true };
-
-      const url = qs.stringifyUrl({
-        url: 'notification.html',
-        query: {
-          callId,
-          portId,
-          metadataJson: JSON.stringify(newMetadata),
-          argsJson: JSON.stringify({ whitelist, canistersInfo, timeout }),
-          type: 'allowAgent',
-        },
-      });
-
-      const height = keyring?.isUnlocked
-        ? Math.min(422 + 37 * whitelist.length, 600)
-        : SIZES.loginHeight;
-
-      extension.windows.create({
-        url,
-        type: 'popup',
-        width: SIZES.width,
-        height,
-        top: 65,
-        left: metadata.pageWidth - SIZES.width,
-      });
-
-      return;
-    } else {
-      const url = qs.stringifyUrl({
-        url: 'notification.html',
-        query: {
-          callId,
-          portId,
-          url: domainUrl,
-          icon: icons[0] || null,
-          argsJson: JSON.stringify({ timeout }),
-          type: 'connect',
-        },
-      });
-
-      const height = keyring?.isUnlocked
-        ? SIZES.appConnectHeight
-        : SIZES.loginHeight;
-
-      extension.windows.create({
-        url,
-        type: 'popup',
-        width: SIZES.width,
-        height,
-      });
-    }
-  },
-};
-
-export const HANDLER_OBJECTS = [isConnected, disconnect, requestConnect];
-
-export class connectionModule {
-  constructor(backgroundController, secureController, keyring) {
-    this.backgroundController = backgroundController;
-    this.secureController = secureController;
-    this.keyring = keyring;
+  // Utils
+  #getHandlerObjects() {
+    return [this.#isConnected(), this.#disconnect(), this.#requestConnect()];
   }
 
   #secureWrapper({ args, handlerObject }) {
     return this.secureController(
       args[0].callback,
       async () => {
-        handlerObject.handler(...args, this.keyring);
+        handlerObject.handler(...args);
       }
     );
   }
 
-  exposeMethods(backgroundController) {
-    HANDLER_OBJECTS.forEach(handlerObject => {
-      backgroundController.exposeController(
+  async #fetchCanistersInfo(whitelist) {
+    if (whitelist && whitelist.length > 0) {
+      const canistersInfo = await Promise.all(
+        whitelist.map(async (id) => {
+          let canisterInfo = { id };
+
+          try {
+            const fetchedCanisterInfo = await PlugController.getCanisterInfo(id);
+            canisterInfo = { id, ...fetchedCanisterInfo };
+          } catch (error) {
+            /* eslint-disable-next-line */
+            console.error(error);
+          }
+
+          return canisterInfo;
+        }),
+      );
+
+      const sortedCanistersInfo = canistersInfo.sort((a, b) => {
+        if (a.name && !b.name) return -1;
+        return 1;
+      });
+
+      return sortedCanistersInfo;
+    }
+
+    return [];
+  }
+
+  // Handlers
+  #isConnected() {
+    return {
+      methodName: 'isConnected',
+      handler: async (opts, url) => {
+        const { callback } = opts;
+
+        getApp(this.keyring.currentWalletId.toString(), url, (app) => {
+          if (app) {
+            callback(null, app.status === CONNECTION_STATUS.accepted);
+            return;
+          }
+
+          callback(null, false);
+        });
+      },
+    };
+  };
+
+  #disconnect() {
+    return {
+      methodName: 'disconnect',
+      handler: async (opts, url) => {
+        removeApp(this.keyring.currentWalletId.toString(), url, (removed) => {
+          if (!removed) {
+            opts.callback(ERRORS.CONNECTION_ERROR, null);
+          }
+        });
+      },
+    };
+  };
+
+  #requestConnect() {
+    return {
+      methodName: 'requestConnect',
+      handler: async (opts, metadata, whitelist, timeout) => {
+        let canistersInfo = [];
+        const isValidWhitelist = Array.isArray(whitelist) && whitelist.length;
+        if (!whitelist.every((canisterId) => validatePrincipalId(canisterId))) {
+          opts.callback(ERRORS.CANISTER_ID_ERROR, null);
+          return;
+        }
+        const { message, sender } = opts;
+        const { id: callId } = message.data.data;
+        const { id: portId } = sender;
+        const { url: domainUrl, name, icons } = metadata;
+
+        if (isValidWhitelist) {
+          canistersInfo = await this.#fetchCanistersInfo(whitelist);
+        }
+
+        const date = new Date().toISOString();
+
+        getApps(this.keyring.currentWalletId.toString(), (apps = {}) => {
+          const newApps = {
+            ...apps,
+            [domainUrl]: {
+              url: domainUrl,
+              name,
+              status: CONNECTION_STATUS.pending,
+              icon: icons[0] || null,
+              timeout,
+              date,
+              events: [
+                ...apps[domainUrl]?.events || [],
+              ],
+              whitelist,
+            },
+          };
+          setApps(this.keyring.currentWalletId.toString(), newApps);
+        });
+
+        // if we receive a whitelist, we create agent
+        if (isValidWhitelist) {
+          const newMetadata = { ...metadata, requestConnect: true };
+
+          const url = qs.stringifyUrl({
+            url: 'notification.html',
+            query: {
+              callId,
+              portId,
+              metadataJson: JSON.stringify(newMetadata),
+              argsJson: JSON.stringify({ whitelist, canistersInfo, timeout }),
+              type: 'allowAgent',
+            },
+          });
+
+          const height = this.keyring?.isUnlocked
+            ? Math.min(422 + 37 * whitelist.length, 600)
+            : SIZES.loginHeight;
+
+          extension.windows.create({
+            url,
+            type: 'popup',
+            width: SIZES.width,
+            height,
+            top: 65,
+            left: metadata.pageWidth - SIZES.width,
+          });
+
+          return;
+        } else {
+          const url = qs.stringifyUrl({
+            url: 'notification.html',
+            query: {
+              callId,
+              portId,
+              url: domainUrl,
+              icon: icons[0] || null,
+              argsJson: JSON.stringify({ timeout }),
+              type: 'connect',
+            },
+          });
+
+          const height = this.keyring?.isUnlocked
+            ? SIZES.appConnectHeight
+            : SIZES.loginHeight;
+
+          extension.windows.create({
+            url,
+            type: 'popup',
+            width: SIZES.width,
+            height,
+          });
+        }
+      },
+    };
+  }
+
+  // Exposer
+  exposeMethods() {
+    this.#getHandlerObjects().forEach(handlerObject => {
+      this.backgroundController.exposeController(
         handlerObject.methodName,
         async (...args) => this.#secureWrapper({ args, handlerObject })
       );

--- a/source/Modules/Controller/connection.js
+++ b/source/Modules/Controller/connection.js
@@ -1,0 +1,166 @@
+import qs from 'query-string';
+import extension from 'extensionizer';
+import ERRORS from '@background/errors';
+import PlugController from '@psychedelic/plug-controller';
+import { validatePrincipalId } from '@shared/utils/ids';
+import { CONNECTION_STATUS } from '@shared/constants/connectionStatus';
+import {
+  getApps,
+  setApps,
+  getApp,
+  removeApp
+} from '../storageManager';
+import SIZES from '../../Pages/Notification/components/Transfer/constants';
+
+// Utils
+const fetchCanistersInfo = async (whitelist) => {
+  if (whitelist && whitelist.length > 0) {
+    const canistersInfo = await Promise.all(
+      whitelist.map(async (id) => {
+        let canisterInfo = { id };
+
+        try {
+          const fetchedCanisterInfo = await PlugController.getCanisterInfo(id);
+          canisterInfo = { id, ...fetchedCanisterInfo };
+        } catch (error) {
+          /* eslint-disable-next-line */
+          console.error(error);
+        }
+
+        return canisterInfo;
+      }),
+    );
+
+    const sortedCanistersInfo = canistersInfo.sort((a, b) => {
+      if (a.name && !b.name) return -1;
+      return 1;
+    });
+
+    return sortedCanistersInfo;
+  }
+
+  return [];
+};
+
+// Handler objects
+export const isConnected = {
+  methodName: 'isConnected',
+  handler: async (opts, url, keyring) => {
+    const { callback } = opts;
+
+    getApp(keyring.currentWalletId.toString(), url, (app) => {
+      if (app) {
+        callback(null, app.status === CONNECTION_STATUS.accepted);
+        return;
+      }
+
+      callback(null, false);
+    });
+  },
+};
+
+export const disconnect = {
+  methodName: 'disconnect',
+  handler: async (opts, url, keyring) => {
+    removeApp(keyring.currentWalletId.toString(), url, (removed) => {
+      if (!removed) {
+        opts.callback(ERRORS.CONNECTION_ERROR, null);
+      }
+    });
+  },
+};
+
+export const requestConnect = {
+  methodName: 'requestConnect',
+  handler: async (opts, metadata, whitelist, timeout, keyring) => {
+    let canistersInfo = [];
+    const isValidWhitelist = Array.isArray(whitelist) && whitelist.length;
+    if (!whitelist.every((canisterId) => validatePrincipalId(canisterId))) {
+      opts.callback(ERRORS.CANISTER_ID_ERROR, null);
+      return;
+    }
+    const { message, sender } = opts;
+    const { id: callId } = message.data.data;
+    const { id: portId } = sender;
+    const { url: domainUrl, name, icons } = metadata;
+
+    if (isValidWhitelist) {
+      canistersInfo = await fetchCanistersInfo(whitelist);
+    }
+
+    const date = new Date().toISOString();
+
+    getApps(keyring.currentWalletId.toString(), (apps = {}) => {
+      const newApps = {
+        ...apps,
+        [domainUrl]: {
+          url: domainUrl,
+          name,
+          status: CONNECTION_STATUS.pending,
+          icon: icons[0] || null,
+          timeout,
+          date,
+          events: [
+            ...apps[domainUrl]?.events || [],
+          ],
+          whitelist,
+        },
+      };
+      setApps(keyring.currentWalletId.toString(), newApps);
+    });
+
+    // if we receive a whitelist, we create agent
+    if (isValidWhitelist) {
+      const newMetadata = { ...metadata, requestConnect: true };
+
+      const url = qs.stringifyUrl({
+        url: 'notification.html',
+        query: {
+          callId,
+          portId,
+          metadataJson: JSON.stringify(newMetadata),
+          argsJson: JSON.stringify({ whitelist, canistersInfo, timeout }),
+          type: 'allowAgent',
+        },
+      });
+
+      const height = keyring?.isUnlocked
+        ? Math.min(422 + 37 * whitelist.length, 600)
+        : SIZES.loginHeight;
+
+      extension.windows.create({
+        url,
+        type: 'popup',
+        width: SIZES.width,
+        height,
+        top: 65,
+        left: metadata.pageWidth - SIZES.width,
+      });
+
+      return;
+    } else {
+      const url = qs.stringifyUrl({
+        url: 'notification.html',
+        query: {
+          callId,
+          portId,
+          url: domainUrl,
+          icon: icons[0] || null,
+          argsJson: JSON.stringify({ timeout }),
+          type: 'connect',
+        },
+      });
+
+      const height = keyring?.isUnlocked
+        ? SIZES.appConnectHeight
+        : SIZES.loginHeight;
+
+      extension.windows.create({
+        url,
+        type: 'popup',
+        width: SIZES.width,
+        height,
+      });
+    }
+  },
+};

--- a/source/Modules/Controller/connection.js
+++ b/source/Modules/Controller/connection.js
@@ -76,10 +76,10 @@ export class ConnectionModule {
         const { id: callId } = message.data.data;
         const { id: portId } = sender;
 
-        getApp(keyring.currentWalletId.toString(), url, async (apps = {}) => {
+        getApp(this.keyring?.currentWalletId?.toString(), url, async (apps = {}) => {
           const app = apps?.[url] || {};
           if (app?.status === CONNECTION_STATUS.accepted) {
-            if (!keyring.isUnlocked) {
+            if (!this.keyring?.isUnlocked) {
               const modalUrl = qs.stringifyUrl({
                 url: 'notification.html',
                 query: {
@@ -98,8 +98,8 @@ export class ConnectionModule {
                 height: SIZES.loginHeight,
               });
             } else {
-              await keyring.getState();
-              const publicKey = await keyring.getPublicKey();
+              await this.keyring?.getState();
+              const publicKey = await this.keyring?.getPublicKey();
               const { host, timeout, whitelist } = app;
               callback(null, {
                 host, whitelist: Object.keys(whitelist), timeout, publicKey,
@@ -119,12 +119,12 @@ export class ConnectionModule {
       handler: async (opts, url, _, callId, portId) => {
         const { callback } = opts;
 
-        getApp(keyring.currentWalletId.toString(), url, async (apps = {}) => {
+        getApp(this.keyring?.currentWalletId?.toString(), url, async (apps = {}) => {
           const app = apps?.[url] || {};
           callback(null, true);
 
           if (app?.status === CONNECTION_STATUS.accepted) {
-            const publicKey = await keyring.getPublicKey();
+            const publicKey = await this.keyring?.getPublicKey();
             const { host, timeout, whitelist } = app;
             callback(null, {
               host, whitelist: Object.keys(whitelist), timeout, publicKey,
@@ -141,7 +141,7 @@ export class ConnectionModule {
     return {
       methodName: 'disconnect',
       handler: async (opts, url) => {
-        removeApp(this.keyring.currentWalletId.toString(), url, (removed) => {
+        removeApp(this.keyring?.currentWalletId?.toString(), url, (removed) => {
           if (!removed) {
             opts.callback(ERRORS.CONNECTION_ERROR, null);
           }
@@ -171,7 +171,7 @@ export class ConnectionModule {
 
         const date = new Date().toISOString();
 
-        getApps(this.keyring.currentWalletId.toString(), (apps = {}) => {
+        getApps(this.keyring?.currentWalletId.toString(), (apps = {}) => {
           const newApps = {
             ...apps,
             [domainUrl]: {
@@ -187,7 +187,7 @@ export class ConnectionModule {
               whitelist,
             },
           };
-          setApps(this.keyring.currentWalletId.toString(), newApps);
+          setApps(this.keyring?.currentWalletId.toString(), newApps);
         });
 
         // if we receive a whitelist, we create agent

--- a/source/Modules/Controller/index.js
+++ b/source/Modules/Controller/index.js
@@ -1,0 +1,1 @@
+export * from './connection';

--- a/source/Modules/index.js
+++ b/source/Modules/index.js
@@ -1,1 +1,2 @@
 export * from './storageManager';
+export * from './Controller';

--- a/source/Modules/storageManager.js
+++ b/source/Modules/storageManager.js
@@ -29,6 +29,14 @@ export const getApps = (currentWalletId, cb) => {
   ));
 };
 
+export const getApp = (currentWalletId, appUrl, cb) => {
+  const defaultValue = {};
+
+  secureGetWrapper(currentWalletId, defaultValue, (state) => (
+    cb(state?.[parseInt(currentWalletId, 10)]?.apps?.[appUrl] || defaultValue)
+  ));
+};
+
 export const setApps = (currentWalletId, apps, cb = () => {}) => {
   const defaultValue = false;
 


### PR DESCRIPTION
## Changelog

- Added the `getApp` to the `StorageModule` to avoid using the `getApps` and then extracting a specific app.
- Introduces the `ConnectionModule`, modularizes all the connection related `BackgroundScript` methods (`requestConnect`, `isConnected`, `disconnect`)
- Had to initialize the keyring before exposing the methods to ensure the `keyring` is being passed correctly to the `ConnectionModule`
- Since we are approaching the refactor in steps and don't want to pr the whole refactor I'm going to refactor the `BackgroundScript` itself after modularizing all the methods.

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [ ] Bug fixes
- [ ] Styling
- [x] Code Refactor

### Clubhouse Tickets Related:

- Ticket 1
- Ticket 2
- Ticket 3

### Screenshots/Gifs:

*Place you changes screenshots here*

### Notes:

*Place special notes here*

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
