### PR TITLE
Refused connection Activity

### DIFF
--- a/source/Pages/Notification/components/AllowAgent/index.jsx
+++ b/source/Pages/Notification/components/AllowAgent/index.jsx
@@ -76,7 +76,7 @@ const AllowAgent = ({
 
   useEffect(() => {
     setOnTimeout(() => () => {
-      handleAllowAgent(CONNECTION_STATUS.rejected).then(() => {
+      handleAllowAgent(CONNECTION_STATUS.refused).then(() => {
         setHandled(true);
         window?.close?.();
       });
@@ -103,7 +103,7 @@ const AllowAgent = ({
 
   window.onbeforeunload = () => {
     if (!handled) {
-      handleAllowAgent(CONNECTION_STATUS.rejected);
+      handleAllowAgent(CONNECTION_STATUS.refused);
     }
   };
 
@@ -175,7 +175,7 @@ const AllowAgent = ({
                     onClick={() => handleAllowAgent(
                       args?.updateWhitelist
                         ? CONNECTION_STATUS.rejectedAgent
-                        : CONNECTION_STATUS.rejected,
+                        : CONNECTION_STATUS.refused,
                     )}
                     style={{ width: '96%' }}
                     fullWidth

--- a/source/Pages/Notification/components/AppConnection/index.jsx
+++ b/source/Pages/Notification/components/AppConnection/index.jsx
@@ -49,7 +49,7 @@ const AppConnection = ({ setOnTimeout }) => {
   } = query;
 
   const handleResponse = async () => {
-    const success = await portRPC.call('handleAllowAgent', [url, { status: status || CONNECTION_STATUS.rejected, whitelist: [] }, callId, portId]);
+    const success = await portRPC.call('handleAllowAgent', [url, { status: status || CONNECTION_STATUS.refused, whitelist: [] }, callId, portId]);
     if (success) {
       window.close();
     }
@@ -71,13 +71,13 @@ const AppConnection = ({ setOnTimeout }) => {
 
   window.onbeforeunload = () => {
     if (status === null) {
-      setStatus(CONNECTION_STATUS.rejected);
+      setStatus(CONNECTION_STATUS.refused);
     }
   };
 
   useEffect(() => {
     setOnTimeout(() => () => {
-      setStatus(CONNECTION_STATUS.rejected);
+      setStatus(CONNECTION_STATUS.refused);
     });
     sendMessage({ type: HANDLER_TYPES.GET_STATE, params: {} },
       (state) => {
@@ -100,7 +100,7 @@ const AppConnection = ({ setOnTimeout }) => {
                   <Button
                     variant="default"
                     value={t('common.decline')}
-                    onClick={() => setStatus(CONNECTION_STATUS.rejected)}
+                    onClick={() => setStatus(CONNECTION_STATUS.refused)}
                     style={{ width: '96%' }}
                     fullWidth
                   />

--- a/source/shared/constants/connectionStatus.js
+++ b/source/shared/constants/connectionStatus.js
@@ -5,4 +5,5 @@ export const CONNECTION_STATUS = {
   rejected: 'rejected',
   rejectedAgent: 'rejectedAgent',
   disconnected: 'disconnected',
+  refused: 'refused',
 };

--- a/source/ui/ActivityItem/components/items/PlugItem.js
+++ b/source/ui/ActivityItem/components/items/PlugItem.js
@@ -13,6 +13,12 @@ const PlugItem = ({
 }) => {
   const classes = useStyles();
   const { t } = useTranslation();
+
+  // So it doesn't display refused connections
+  if (status === CONNECTION_STATUS.refused) {
+    return null;
+  }
+
   return (
     <ActivityItemDisplay
       image={<img className={classes.image} src={icon} />}

--- a/source/ui/ActivityItem/index.jsx
+++ b/source/ui/ActivityItem/index.jsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import extension from 'extensionizer';
 import ReactJson from 'react-json-view';
 
+import { CONNECTION_STATUS } from '@shared/constants/connectionStatus';
 import { getICNetworkStatusUrl } from '@shared/constants/urls';
 import { Dialog } from '@ui';
 
@@ -64,9 +65,13 @@ const ActivityItem = (props) => {
     }, 1500);
   };
 
+  const isTransaction = ['SEND', 'RECEIVE'].includes(type) && symbol === 'ICP';
+
   const getComponent = () => {
     if (type === 'PLUG') {
-      return PlugItem;
+      const { status } = props;
+
+      return status === CONNECTION_STATUS.refused ? null : PlugItem;
     }
     if (type === 'SWAP') {
       return SwapItem;
@@ -78,9 +83,12 @@ const ActivityItem = (props) => {
 
     return TokenItem;
   };
+
   const Component = getComponent();
 
-  const isTransaction = ['SEND', 'RECEIVE'].includes(type) && symbol === 'ICP';
+  // If component is null should return null to avoid weird spacing
+  if (Component === null) return null;
+
   return (
     <div
       className={clsx(classes.root, isTransaction && classes.pointer)}


### PR DESCRIPTION
## Changelog

- Added refused to `ConnectionStatus` that way we stop showing `unplugged` when the user rejects the connection to the app.

### Type of changes included:

- [ ] Components
- [x] Business Logic
- [ ] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- Ticket 1
- Ticket 2
- Ticket 3

### Screenshots

https://user-images.githubusercontent.com/44899916/165116763-fe17f8f3-33bc-46bf-a178-811e04da76bd.mp4

> On the video we can see how after refusing the connection two times (via cancel button & closing the modal) the activity tab doesn't log anything (as it's supposed to be)

### Notes:

Note that we are storing the refused connection, that way if we want to display it in the future it will work in retroactively . 🚀 

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
