### PR TITLE
Added error message to account creation when name is too long

### DIFF
--- a/source/components/Profile/index.jsx
+++ b/source/components/Profile/index.jsx
@@ -60,6 +60,7 @@ const Profile = ({ disableProfile }) => {
   const [openCreateAccount, setOpenCreateAccount] = useState(false);
   const [openConnectAccount, setOpenConnectAccount] = useState(false);
   const [accountName, setAccountName] = useState('');
+  const [error, setError] = useState(null);
   const [connectedWallets, setConnectedWallets] = useState([]);
 
   const handleToggle = () => {
@@ -80,7 +81,12 @@ const Profile = ({ disableProfile }) => {
   }, []);
 
   const handleChangeAccountName = (e) => {
-    setAccountName(e.target.value);
+    const name = e.target.value;
+    if (name.length > 24) {
+      setError(t('profile.accountNameTooLong'));
+    } else {
+      setAccountName(e.target.value);
+    }
   };
 
   const handleEditAccount = (e) => {
@@ -198,19 +204,23 @@ const Profile = ({ disableProfile }) => {
         open={openCreateAccount}
         title={t('settings.createAccountTitle')}
         content={(
-          <FormItem
-            label={t('common.name')}
-            smallLabel
-            component={(
-              <TextInput
-                fullWidth
-                value={accountName}
-                onChange={handleChangeAccountName}
-                type="text"
-                className={classes.createAccountInput}
-              />
-            )}
-          />
+          <div>
+            <FormItem
+              label={t('common.name')}
+              smallLabel
+              component={(
+                <TextInput
+                  fullWidth
+                  value={accountName}
+                  onChange={handleChangeAccountName}
+                  type="text"
+                  className={classes.createAccountInput}
+                  error={!!error}
+                />
+              )}
+            />
+            {error && <span className={classes.errorMessage}>{error}</span>}
+          </div>
         )}
         button={t('common.create')}
         buttonVariant="rainbow"

--- a/source/components/Profile/styles.js
+++ b/source/components/Profile/styles.js
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-export default makeStyles({
+export default makeStyles((theme) => ({
   fancyCircle: {
     width: 37,
     height: 37,
@@ -61,4 +61,7 @@ export default makeStyles({
   createAccountInput: {
     marginBottom: '6px',
   },
-});
+  errorMessage: {
+    color: theme.palette.danger.main,
+  },
+}));

--- a/source/locales/en/translation.json
+++ b/source/locales/en/translation.json
@@ -18,7 +18,8 @@
     "wantToConnect": "Do you want to connect your accounts?",
     "help": "Help",
     "lock": "Lock",
-    "refreshWallet": "Refresh Wallet"
+    "refreshWallet": "Refresh Wallet",
+    "accountNameTooLong": "Account name must be less than 24 characters long"
   },
   "tabs": {
     "tokens": "Tokens",


### PR DESCRIPTION
## Changelog
- Added error message when trying to edit wallet name with name longer than 24 chars

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [X] Bug fixes
- [ ] Styling
- [ ] Code Refactor


### Tested on:

- [X] Chrome
- [ ] Firefox
- [ ] Safari
