### PR TITLE
Chore: Account switch improvements

### DIFF
--- a/source/components/ActionDialog/index.jsx
+++ b/source/components/ActionDialog/index.jsx
@@ -11,7 +11,7 @@ import { Button } from '@ui';
 import useStyles from './styles';
 
 const ActionDialog = ({
-  title, content, button, buttonVariant, onClick, onClose, open, className,
+  title, content, confirmText, cancelText, buttonVariant, onClick, onClose, open, className,
 }) => {
   const classes = useStyles();
 
@@ -33,14 +33,14 @@ const ActionDialog = ({
         <div className={classes.buttonContainer}>
           <Button
             variant="default"
-            value="Cancel"
+            value={cancelText}
             onClick={onClose}
             style={{ width: '96%' }}
             fullWidth
           />
           <Button
             variant={buttonVariant}
-            value={button}
+            value={confirmText}
             onClick={onClick}
             style={{ width: '96%' }}
             wrapperStyle={{ textAlign: 'right' }}
@@ -57,14 +57,17 @@ export default ActionDialog;
 ActionDialog.propTypes = {
   title: PropTypes.string.isRequired,
   content: PropTypes.node.isRequired,
-  button: PropTypes.string.isRequired,
   buttonVariant: PropTypes.string.isRequired,
   onClick: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   open: PropTypes.bool.isRequired,
+  confirmText: PropTypes.string,
+  cancelText: PropTypes.string,
   className: PropTypes.string,
 };
 
 ActionDialog.defaultProps = {
   className: '',
+  confirmText: 'Confirm',
+  cancelText: 'Cancel',
 };

--- a/source/components/Apps/index.jsx
+++ b/source/components/Apps/index.jsx
@@ -76,7 +76,7 @@ const Apps = () => {
             open={openDelete}
             title={t('apps.disconnectTitle')}
             content={<Typography>{t('apps.disconnectText')} <b>{selectedApp.name}</b>?</Typography>}
-            button={t('common.disconnect')}
+            confirmText={t('common.disconnect')}
             buttonVariant="danger"
             onClick={() => handleRemoveApp(selectedApp)}
             onClose={() => setOpenDelete(false)}

--- a/source/components/ConnectAccountsModal/components/ConnectAccountItem/index.jsx
+++ b/source/components/ConnectAccountsModal/components/ConnectAccountItem/index.jsx
@@ -10,7 +10,7 @@ import useStyles from './styles';
 import UserIcon from '../../../UserIcon';
 
 const ConnectAccountItem = ({
-  connected, wallet, checked, onCheck,
+  connected, wallet, checked, onCheck, name,
 }) => {
   const classes = useStyles();
   return (
@@ -29,7 +29,7 @@ const ConnectAccountItem = ({
           handleChange={!connected && onCheck(wallet.walletNumber)}
         />
         <UserIcon size="small" icon={wallet.icon} style={{ marginLeft: -6, marginRight: 12 }} />
-        <Typography variant="h6" className={classes.walletName}>{wallet.name}</Typography>
+        <Typography variant="h6" className={classes.walletName}>{name || ''}</Typography>
       </div>
       <Typography variant="h6">{shortAddress(wallet.principal)}</Typography>
     </div>
@@ -41,6 +41,7 @@ ConnectAccountItem.propTypes = {
   connected: PropTypes.bool.isRequired,
   checked: PropTypes.bool.isRequired,
   onCheck: PropTypes.func.isRequired,
+  name: PropTypes.string.isRequired,
 };
 
 export default ConnectAccountItem;

--- a/source/components/ConnectAccountsModal/index.jsx
+++ b/source/components/ConnectAccountsModal/index.jsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import PropTypes from 'prop-types';
 
 import { getApps, setApps } from '@modules/storageManager';
 import { CONNECTION_STATUS } from '@shared/constants/connectionStatus';
 import { getTabURL } from '@shared/utils/chrome-tabs';
+import { getMultipleReverseResolvedNames } from '@shared/services/ICNS';
 
 import ActionDialog from '../ActionDialog';
 import useStyles from './styles';
@@ -23,6 +24,17 @@ const ConnectAccountsModal = ({
   const { t } = useTranslation();
   const [walletsToUpdate, setWalletsToUpdate] = useState({});
   const [selectAllWallets, setSelectAllWallets] = useState(false);
+  const [icnsNames, setICNSNames] = useState({});
+
+  const getReverseResolvedNames = async () => {
+    const principals = wallets.map((wallet) => wallet.principal);
+    const names = await getMultipleReverseResolvedNames(principals);
+    setICNSNames(names);
+  };
+
+  useEffect(() => {
+    getReverseResolvedNames();
+  }, [wallets]);
 
   const connectAccountToTab = (wallet) => {
     getApps(wallet.walletNumber.toString(), (apps) => {
@@ -74,9 +86,9 @@ const ConnectAccountsModal = ({
   return (
     <ActionDialog
       open={open}
-      title={t('profile.subaccountNotConnected')}
       className={classes.modalContainer}
-      button={t('common.allow')}
+      confirmText={t('common.allow')}
+      cancelText={t('common.decline')}
       buttonVariant="rainbow"
       onClick={handleConfirm}
       onClose={onClose}
@@ -90,6 +102,7 @@ const ConnectAccountsModal = ({
           onCheckWallet={onCheckWallet}
           connectedWallets={connectedWallets}
           walletsToUpdate={walletsToUpdate}
+          icnsNames={icnsNames}
         />
 )}
     />

--- a/source/components/ConnectAccountsModal/layout.jsx
+++ b/source/components/ConnectAccountsModal/layout.jsx
@@ -20,6 +20,7 @@ const ConnectAccountsModalLayout = ({
   onCheckWallet,
   connectedWallets,
   walletsToUpdate,
+  icnsNames,
 }) => {
   const { t } = useTranslation();
   const { onScroll, fullScroll } = useScroll();
@@ -48,6 +49,7 @@ const ConnectAccountsModalLayout = ({
           const alreadyConnected = connectedWallets.includes(wallet.walletNumber);
           return (
             <ConnectAccountItem
+              name={icnsNames[wallet?.principal] || wallet?.name}
               wallet={wallet}
               connected={alreadyConnected}
               checked={
@@ -73,10 +75,12 @@ ConnectAccountsModalLayout.propTypes = {
   app: PropTypes.objectOf(PropTypes.string).isRequired,
   tab: PropTypes.objectOf(PropTypes.string).isRequired,
   selectAllWallets: PropTypes.bool.isRequired,
+  icnsNames: PropTypes.objectOf(PropTypes.string),
 };
 
 ConnectAccountsModalLayout.defaultProps = {
   connectedWallets: [],
+  icnsNames: {},
 };
 
 export default ConnectAccountsModalLayout;

--- a/source/components/ContactList/index.jsx
+++ b/source/components/ContactList/index.jsx
@@ -49,7 +49,7 @@ const ContactList = ({
             open={open}
             title={t('contacts.deleteTitle')}
             content={<Typography>{t('contacts.deleteText')} <b>{selectedContact.name}</b>?</Typography>}
-            button={t('contacts.deleteButton')}
+            confirmText={t('contacts.deleteButton')}
             buttonVariant="danger"
             onClick={() => { handleRemoveContact(selectedContact); setOpen(false); }}
             onClose={() => setOpen(false)}

--- a/source/components/IDInput/index.jsx
+++ b/source/components/IDInput/index.jsx
@@ -167,7 +167,7 @@ const IDInput = ({
                     )}
                   />
                 )}
-                button={t('common.add')}
+                confirmText={t('common.add')}
                 buttonVariant="rainbow"
                 onClick={addContact}
                 onClose={() => setIsContactsOpened(false)}

--- a/source/components/Profile/index.jsx
+++ b/source/components/Profile/index.jsx
@@ -184,6 +184,12 @@ const Profile = ({ disableProfile }) => {
     setOpenCreateAccount(true);
   };
 
+  const handleDeclineConnect = () => {
+    executeAccountSwitch(selectedWallet);
+    setOpenConnectAccount(false);
+    setSelectedWallet(null);
+  };
+
   return (
     <>
       <HoverAnimation
@@ -224,14 +230,14 @@ const Profile = ({ disableProfile }) => {
             {error && <span className={classes.errorMessage}>{error}</span>}
           </div>
         )}
-        button={t('common.create')}
+        confirmText={t('common.create')}
         buttonVariant="rainbow"
         onClick={handleCreateAccount}
         onClose={() => setOpenCreateAccount(false)}
       />
       <ConnectAccountsModal
         open={openConnectAccount}
-        onClose={() => setOpenConnectAccount(false)}
+        onClose={handleDeclineConnect}
         onConfirm={() => executeAccountSwitch(selectedWallet)}
         wallets={accounts}
         connectedWallets={connectedWallets}

--- a/source/shared/utils/ic/icns/reverse_registrar.did.js
+++ b/source/shared/utils/ic/icns/reverse_registrar.did.js
@@ -1,0 +1,9 @@
+export default ({ IDL }) => {
+  const Result = IDL.Variant({ ok: IDL.Text, err: IDL.Text });
+  const ICNSReverseRegistrar = IDL.Service({
+    getName: IDL.Func([IDL.Principal], [IDL.Text], ['query']),
+    setName: IDL.Func([IDL.Text], [Result], []),
+  });
+  return ICNSReverseRegistrar;
+};
+export const init = ({ IDL }) => [IDL.Principal, IDL.Principal, IDL.Text];


### PR DESCRIPTION
## Changelog
- Added ICNS reverse resolution helper and reverse-resolve names in the modal.
- Changed 'Cancel' to decline
- Execute account switch even if not connecting the new account
- Fixed modal styles

### Type of changes included:

- [ ] Components
- [X] Business Logic
- [X] Bug fixes
- [X] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

https://www.notion.so/Plug-Extension-631a299f3ec14b9c9522e29a9800e923?p=89b0adf157e24dc4b7186dfa2128d489



### Tested on:

- [X] Chrome
- [ ] Firefox
- [ ] Safari
