### PR TITLE
Appear card contact when paste or type principal id

### DIFF
--- a/source/components/IDInput/index.jsx
+++ b/source/components/IDInput/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React, { useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
@@ -28,6 +29,7 @@ const IDInput = ({
   const [isContactsOpened, setIsContactsOpened] = useState(false);
   const [contactName, setContactName] = useState('');
   const [openContacts, setOpenContacts] = useState(false);
+  // const [rawContacts, setRawsContacts] = useState([]);
 
   const { principalId, accountId } = useSelector((state) => state.wallet);
   const { groupedContacts: contacts } = useSelector((state) => state.contacts);
@@ -80,6 +82,17 @@ const IDInput = ({
     setContactName(e.target.value);
   };
 
+  const searchContactFromId = (e) => {
+    onChange(e.target.value);
+    contacts.forEach((contact) => {
+      contact.contacts.forEach((i) => {
+        if (e.target.value === i.id) {
+          setSelectedContact(i);
+        }
+      });
+    });
+  };
+
   return (
     <>
       <div className={classes.root}>
@@ -103,7 +116,7 @@ const IDInput = ({
               fullWidth
               value={value}
               type="text"
-              onChange={(e) => onChange(e.target.value)}
+              onChange={(e) => searchContactFromId(e)}
               placeholder={placeholder || t('send.inputId')}
               {...other}
             />


### PR DESCRIPTION

### Added a replacement of the Principal ID for the name of the contact, if this Principal ID has already been added to the contact book

### Type of changes included:

- [x] Components
- [ ] Business Logic
- [x] Bug fixes
- [ ] Styling
- [ ] Code Refactor

### Notion Ticket Related:
https://www.notion.so/QA-Improvement-Replace-principal-by-the-contact-if-its-saved2-8bb47f9a02b2475fb9ddb01985236f25

### Screenshots/Gifs:
![1](https://user-images.githubusercontent.com/52618089/178741933-d875bdab-7aad-4db8-8564-e2d5e329d809.gif)

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
