### PR TITLE
Fix/account changing emoji

### DIFF
--- a/source/components/Profile/index.jsx
+++ b/source/components/Profile/index.jsx
@@ -271,13 +271,14 @@ const Profile = ({ disableProfile }) => {
               <MenuList className={clsx(classes.accountContainer, classes.menu)}>
                 {
                   accounts.map((account) => {
+                    console.log(account)
                     const isHidden = hiddenAccounts.includes(account.walletNumber);
                     return (!isHidden || isEditing) && (
                       <MenuItem
                         size="small"
                         key={account.walletNumber}
                         name={account.name}
-                        icon={<UserIcon size="small" icon={account.icon} style={{ marginLeft: -6, marginRight: 12 }} />}
+                        icon={<UserIcon size="small" icon={account.icon ? account.icon : '👽'} style={{ marginLeft: -6, marginRight: 12 }} />}
                         onClick={!isHidden && handleChangeAccount(account.walletNumber)}
                         selected={account.walletNumber === walletNumber}
                         className={clsx(isHidden && classes.hiddenAccount)}

--- a/source/components/Profile/index.jsx
+++ b/source/components/Profile/index.jsx
@@ -271,7 +271,6 @@ const Profile = ({ disableProfile }) => {
               <MenuList className={clsx(classes.accountContainer, classes.menu)}>
                 {
                   accounts.map((account) => {
-                    console.log(account)
                     const isHidden = hiddenAccounts.includes(account.walletNumber);
                     return (!isHidden || isEditing) && (
                       <MenuItem

--- a/source/components/UserIcon/index.jsx
+++ b/source/components/UserIcon/index.jsx
@@ -12,7 +12,7 @@ const UserIcon = ({
 
   const classes = useStyles();
 
-  const displayIcon = icon ?? emoji ?? '👽';
+  const displayIcon = icon ?? emoji;
 
   return (
     <div

--- a/source/components/UserIcon/index.jsx
+++ b/source/components/UserIcon/index.jsx
@@ -12,7 +12,7 @@ const UserIcon = ({
 
   const classes = useStyles();
 
-  const displayIcon = icon ?? emoji;
+  const displayIcon = icon ?? emoji ?? '👽';
 
   return (
     <div


### PR DESCRIPTION
## Now doesnt change the main account emoji when you change to other account

### Type of changes included:

- [x] Components
- [ ] Business Logic
- [x] Bug fixes
- [ ] Styling
- [x] Code Refactor

### Notion Tickets Related:
- https://www.notion.so/BUG-Account-changing-emoji-bug-1bded67c85de45ed8d1dbfb6fb42be68

### Screenshots/Gifs:
![5](https://user-images.githubusercontent.com/52618089/179255223-f8aa37ce-2c1e-44fc-a662-8f2651f82c98.gif)

### Notes:
- we need to rethink how we apply an emoji in the principal account

### Tested on:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
