### PR TITLE
Fix: Switch accounts connect modal title

### DIFF
--- a/source/components/ConnectAccountsModal/styles.js
+++ b/source/components/ConnectAccountsModal/styles.js
@@ -23,6 +23,7 @@ export default makeStyles({
     overflow: 'hidden',
     textAlign: 'center',
     marginBottom: 10,
+    maxWidth: 320,
   },
   scrollShadow: {
     boxShadow: 'inset 0 -10px 10px -10px rgb(0 0 0 / 0.4)',


### PR DESCRIPTION
## Changelog

- Added max width so ellipsis appears on modal title


### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [X] Bug fixes
- [X] Styling
- [ ] Code Refactor

### Clubhouse Tickets Related:

- https://www.notion.so/BUG-Fix-connecting-screen-with-long-names-b2e5b32eafa248cc84995e7b08848d42

### Screenshots/Gifs:

<img width="423" alt="image" src="https://user-images.githubusercontent.com/12738697/180197851-96ba2bdf-c882-465f-a455-09e8c800d0e2.png">


### Tested on:

- [X] Chrome
- [ ] Firefox
- [ ] Safari
