### PR TITLE
Fixed token standard in handleRequestTransfer

### DIFF
--- a/source/Modules/Controller/transaction.js
+++ b/source/Modules/Controller/transaction.js
@@ -136,7 +136,7 @@ export class TransactionModule extends ControllerModuleBase {
               ...transfer,
               amount: parsedAmount,
               canisterId: ICP_CANISTER_ID,
-              standard: 'icp',
+              standard: 'ROSETTA',
             });
 
             if (response.error) {


### PR DESCRIPTION
## Changelog
- Fixes standard used for requestTransfer transactions to `ROSETTA` (default ICP transactions)

### Type of changes included:

- [ ] Components
- [ ] Business Logic
- [X] Bug fixes
- [ ] Styling
- [ ] Code Refactor


### Tested on:

- [X] Chrome
- [ ] Firefox
- [ ] Safari
